### PR TITLE
EHPR-105 scroll to the top of the form

### DIFF
--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -1,5 +1,4 @@
 import Link from 'next/link';
-import Image from 'next/image';
 import { useRouter } from 'next/router';
 import { useEffect, useRef } from 'react';
 
@@ -19,7 +18,7 @@ export const Header: React.FC = () => {
         <div className='layout-grid gap-0 h-full flex flex-row items-center align-center'>
           <Link href='/'>
             <a>
-              <Image src={logo} alt='government of british columbia' width={160} height={45} />
+              <img src={logo.src} alt='government of british columbia' width={160} height={45} />
             </a>
           </Link>
           <div className='ml-7 pl-7 border-l-2 border-bcYellowPrimary'>

--- a/apps/web/src/pages/submission/[step].tsx
+++ b/apps/web/src/pages/submission/[step].tsx
@@ -53,7 +53,7 @@ const Submission = () => {
           please have your registration number available.
         </p>
         <p className='mb-4'>
-          <b>If you encounter problems completing/submitting this form, please email </b>
+          <b>If you encounter problems completing this form, please email </b>
           <ExternalLink href='mailto:EHPRQuestions@gov.bc.ca'>EHPRQuestions@gov.bc.ca</ExternalLink>
           .
         </p>

--- a/apps/web/src/pages/submission/[step].tsx
+++ b/apps/web/src/pages/submission/[step].tsx
@@ -1,6 +1,7 @@
 import { useRouter } from 'next/router';
 
 import { ExternalLink, Form, Stepper } from '@components';
+import { useEffect, useRef } from 'react';
 
 const FORM_STEPS = ['Primary', 'Contact', 'Credential', 'Preferences', 'Review and Submit'];
 
@@ -9,34 +10,70 @@ const Submission = () => {
 
   const step = Number(router.query.step);
 
+  // do not scroll to the top of the form on initial load
+  const formRef = useRef<HTMLDivElement>(null);
+  const prevStepRef = useRef<number>(1);
+  useEffect(() => {
+    if (!isNaN(step) && prevStepRef.current !== step && formRef.current) {
+      window.scrollTo({ left: 0, top: formRef.current.offsetTop, behavior: 'smooth' });
+      prevStepRef.current = step;
+    }
+  }, [step]);
+
   return (
     <>
-      <h1 className='text-4xl mb-3'>Health Provider Registry for BC’s Emergency Response</h1>
-      <section className='mb-4'>
-        <p>
-          Please refer to the <ExternalLink href='#'>FAQ’s</ExternalLink> when completing this form.
+      <h1 className='text-3xl mb-7 mx-6 lg:text-4xl lg:mb-3 lg:mx-0'>
+        Health Provider Registry for BC’s Emergency Response
+      </h1>
+      <section className='mb-7'>
+        <p className='mb-4'>
+          The <b>Emergency Health Provider Registry (EHPR)</b> is an online registry to support the
+          proactive deployment of health care providers to ensure BC’s health care system is best
+          prepared to respond to emergencies (e.g., wildfires, floods, pandemics). It is an online
+          registry of health care professionals and health authority staff who are able and willing
+          to be deployed or hired to support B.C.’s health system response. For more information
+          about the EHPR, please refer to the&nbsp;
+          <ExternalLink href='https://www.heu.org/sites/default/files/2021-08/FAQ%20EHPR_12August2020.pdf'>
+            FAQs
+          </ExternalLink>
+          .
         </p>
-        <p>
-          If you encounter problems completing/submitting this form, please email{' '}
+        <p className='mb-4'>
+          All&nbsp;
+          <ExternalLink href='https://www.heu.org/sites/default/files/2021-08/FAQ%20EHPR_12August2020.pdf'>
+            eligible health care providers or health care staff
+          </ExternalLink>
+          &nbsp;are invited to register using the form below. Health authorities, the Ministry of
+          Health or HealthMatch BC may use the EHPR to initiate contact if/when assistance is
+          required.
+        </p>
+        <p className='mb-4'>
+          The form takes about 10 minutes to complete - if you are in a career stream with oversight
+          from a regulatory or credentialing body (e.g., BC College of Nursing Professionals),
+          please have your registration number available.
+        </p>
+        <p className='mb-4'>
+          <b>If you encounter problems completing/submitting this form, please email </b>
+          <ExternalLink href='mailto:EHPRQuestions@gov.bc.ca'>EHPRQuestions@gov.bc.ca</ExternalLink>
+          .
+        </p>
+        <p className='mb-4'>
+          Your personal information is being collected in compliance with BC privacy legislation
+          under sections 26(c) and (e) of the Freedom of Information and Protection of Privacy Act.
+          Your information will be retained for five years and be shared with the Ministry of
+          Health, Health Match BC and health authorities, to support B.C.’s health emergency
+          response.
+        </p>
+
+        <p className='font-bold'>
+          If you have any questions about our collection or use of personal information, please
+          email your inquiries to&nbsp;
           <ExternalLink href='mailto:EHPRQuestions@gov.bc.ca'>EHPRQuestions@gov.bc.ca</ExternalLink>
           .
         </p>
       </section>
 
-      <p className='font-bold mb-4'>
-        Your personal information is being collected in compliance with BC privacy legislation under
-        section 26(c) and (e) of the Freedom of Information and Protection of Privacy Act. Your
-        information will be retained for five years and be shared with the Ministry of Health,
-        Health Match BC and health authorities, to support B.C.’s health emergency response.
-      </p>
-
-      <p className='font-bold mb-4'>
-        If you have any questions about our collection or use of personal information, please email
-        your inquiries to{' '}
-        <ExternalLink href='mailto:EHPRQuestions@gov.bc.ca'>EHPRQuestions@gov.bc.ca</ExternalLink>.
-      </p>
-
-      <div className='bg-white rounded'>
+      <div className='bg-white rounded' ref={formRef}>
         <div className='p-4 border-b mb-5'>
           <Stepper formSteps={FORM_STEPS} step={step} />
         </div>

--- a/apps/web/src/pages/submission/[step].tsx
+++ b/apps/web/src/pages/submission/[step].tsx
@@ -15,7 +15,7 @@ const Submission = () => {
   const prevStepRef = useRef<number>(1);
   useEffect(() => {
     if (!isNaN(step) && prevStepRef.current !== step && formRef.current) {
-      window.scrollTo({ left: 0, top: formRef.current.offsetTop, behavior: 'smooth' });
+      window.scrollTo(0, formRef.current.offsetTop);
       prevStepRef.current = step;
     }
   }, [step]);


### PR DESCRIPTION
- update header text
- scroll to the top of the form at step transitions
- do not scroll at initial loading
- rollback logo to img element
[exportPathMap](https://nextjs.org/docs/api-reference/next.config.js/exportPathMap) should be defined in `next.config.js` in order to benefit from `image optimization`. But it can't be available because of dynamic paths.