### PR TITLE
Don't limit checks to main branch PRs

### DIFF
--- a/.github/workflows/pr-check-api.yml
+++ b/.github/workflows/pr-check-api.yml
@@ -1,8 +1,6 @@
 name: API PR Checks
 on:
   pull_request:
-    branches:
-      - main
     paths:
       - 'apps/api/**'
       - 'packages/common/**'

--- a/.github/workflows/pr-check-common.yml
+++ b/.github/workflows/pr-check-common.yml
@@ -1,8 +1,6 @@
 name: Common PR Checks
 on:
   pull_request:
-    branches:
-      - main
     paths:
       - 'packages/common/**'
 

--- a/.github/workflows/pr-check-terraform.yml
+++ b/.github/workflows/pr-check-terraform.yml
@@ -1,8 +1,6 @@
 name: Terraform PR Checks
 on:
   pull_request:
-    branches:
-      - main
     paths:
       - 'terraform/**'
 

--- a/.github/workflows/pr-check-web.yml
+++ b/.github/workflows/pr-check-web.yml
@@ -1,8 +1,6 @@
 name: Web PR Checks
 on:
   pull_request:
-    branches:
-      - main
     paths:
       - 'apps/web/**'
       - 'packages/common/**'


### PR DESCRIPTION
When branching away from main we don't get PR checks, this changes that so checks run on all PRs