### PR TITLE
EHPR-147 | Re-enable validation

### DIFF
--- a/apps/api/src/app.config.ts
+++ b/apps/api/src/app.config.ts
@@ -1,7 +1,7 @@
 import { NestFactory } from '@nestjs/core';
 import * as winston from 'winston';
 import { WinstonModule, utilities as nestWinstonModuleUtilities } from 'nest-winston';
-import { Logger } from '@nestjs/common';
+import { Logger, ValidationPipe } from '@nestjs/common';
 import { ExpressAdapter, NestExpressApplication } from '@nestjs/platform-express';
 import express from 'express';
 
@@ -62,12 +62,12 @@ export async function createNestApp(): Promise<{
   // Validation pipe
   app.useGlobalPipes(
     new TrimPipe(),
-    // new ValidationPipe({
-    //   transform: true,
-    //   whitelist: true,
-    //   forbidNonWhitelisted: false,
-    //   enableDebugMessages: true,
-    // }),
+    new ValidationPipe({
+      transform: true,
+      whitelist: true,
+      forbidNonWhitelisted: false,
+      enableDebugMessages: true,
+    }),
   );
 
   // Global Error Filter

--- a/packages/common/src/dto/skill-information.dto.ts
+++ b/packages/common/src/dto/skill-information.dto.ts
@@ -29,6 +29,7 @@ export class SkillInformationDTO {
       this.registrationStatus = base.registrationStatus;
       this.specialties = base.specialties?.map(specialty => new SpecialtyDTO(specialty));
       this.currentEmployment = base.currentEmployment;
+      this.healthAuthorities = base.healthAuthorities;
       this.employmentCircumstance = base.employmentCircumstance;
       this.nonClinicalJobTitle = base.nonClinicalJobTitle;
     }


### PR DESCRIPTION
The issue with re-enabling validation was that health authorities wasn't being assigned in the DTO constructor, seems to be all working now.

https://freshworks.atlassian.net/browse/EHPR-147

Related tickets created:
- Bug: [Array contents are not validated](https://freshworks.atlassian.net/browse/EHPR-185)
- Task: [Log API validation errors in an understandable format](https://freshworks.atlassian.net/browse/EHPR-184)