### PR TITLE
EHPR-184 | Logging API Validations

### DIFF
--- a/apps/api/src/app.config.ts
+++ b/apps/api/src/app.config.ts
@@ -1,7 +1,7 @@
 import { NestFactory } from '@nestjs/core';
 import * as winston from 'winston';
 import { WinstonModule, utilities as nestWinstonModuleUtilities } from 'nest-winston';
-import { Logger, ValidationPipe } from '@nestjs/common';
+import { BadRequestException, Logger, ValidationPipe } from '@nestjs/common';
 import { ExpressAdapter, NestExpressApplication } from '@nestjs/platform-express';
 import express from 'express';
 
@@ -66,7 +66,16 @@ export async function createNestApp(): Promise<{
       transform: true,
       whitelist: true,
       forbidNonWhitelisted: false,
-      enableDebugMessages: true,
+      enableDebugMessages: false,
+      disableErrorMessages: true,
+      exceptionFactory: errors => {
+        const errorMessages = errors.map(error =>
+          error.constraints
+            ? JSON.parse(error.constraints.ValidateNestedObject)
+            : 'Validation Error Not Found',
+        );
+        throw new BadRequestException(errorMessages);
+      },
     }),
   );
 

--- a/apps/api/src/common/error-exception.filter.ts
+++ b/apps/api/src/common/error-exception.filter.ts
@@ -56,8 +56,9 @@ export class ErrorExceptionFilter implements ExceptionFilter {
         ? exception.message
         : exception;
 
-    const privateKeys: string[] = ['password'];
-    const body = typeof request.body === 'object' ? JSON.stringify(request.body) : request.body;
+    const privateKeys: string[] = ['password', 'payload'];
+    const body = typeof request.body === 'string' ? JSON.parse(request.body) : request.body;
+
     privateKeys.forEach(key => {
       if (body[key]) {
         delete body[key];

--- a/apps/api/src/common/error-exception.filter.ts
+++ b/apps/api/src/common/error-exception.filter.ts
@@ -30,12 +30,12 @@ export class ErrorExceptionFilter implements ExceptionFilter {
     return {
       errorType:
         exceptionMessage.error ||
-        (exception as any).response.error ||
+        (exception as any).response?.error ||
         CommonError.INTERNAL_ERROR.errorType,
 
       errorMessage:
         exceptionMessage.message ||
-        (exception as any).response.message ||
+        (exception as any).response?.message ||
         CommonError.INTERNAL_ERROR.errorMessage,
 
       /** If local, return the full error message body */
@@ -63,18 +63,9 @@ export class ErrorExceptionFilter implements ExceptionFilter {
         delete body[key];
       }
     });
-    this.logger.error(
-      `${new Date()}: error thrown with message ${exception.message}`,
-      exception.stack,
-      typeof body === 'object' ? JSON.stringify(body) : body,
-    );
 
-    /** If failed with a server error, logs the problems */
-    if ((status >= 500 && status < 600) || !(exception instanceof GenericException)) {
-      /** Log entire exception */
-      /** If there's an stack, log it */
-      this.logger.error(exception);
-    }
+    // Log errors
+    this.logger.error({ status, stack: exception.stack, body }, null, 'ExceptionFilter');
 
     if (ClassValidationParser.isClassValidatorException(flattenedException)) {
       response

--- a/packages/common/src/dto/is-valid-lha.decorator.ts
+++ b/packages/common/src/dto/is-valid-lha.decorator.ts
@@ -1,7 +1,7 @@
 import { ValidatorConstraint, ValidatorConstraintInterface } from 'class-validator';
 import { LhaId, validLhaIds } from '../helper';
 
-@ValidatorConstraint({ name: 'specialties', async: false })
+@ValidatorConstraint({ name: 'IsArrayOfLhas', async: false })
 export class IsArrayOfLhas implements ValidatorConstraintInterface {
   validate(value: LhaId[]) {
     for (let i = 0; i < value.length; i++) {
@@ -14,6 +14,6 @@ export class IsArrayOfLhas implements ValidatorConstraintInterface {
   }
 
   defaultMessage() {
-    return 'Invalid specialty selection';
+    return 'Invalid location selection';
   }
 }

--- a/packages/common/src/dto/is-valid-submission.decorator.ts
+++ b/packages/common/src/dto/is-valid-submission.decorator.ts
@@ -1,8 +1,9 @@
-import { registerDecorator, ValidationOptions, Validator } from 'class-validator';
+import { registerDecorator, ValidationError, ValidationOptions, Validator } from 'class-validator';
 import { SubmissionPayloadDTO } from './submission-payload.dto';
 
 const validator = new Validator();
 export function IsValidSubmission(validationOptions?: ValidationOptions) {
+  let results: ValidationError[];
   // eslint-disable-next-line @typescript-eslint/ban-types
   return function (object: Object, propertyName: string) {
     registerDecorator({
@@ -13,11 +14,22 @@ export function IsValidSubmission(validationOptions?: ValidationOptions) {
       validator: {
         async validate(value: SubmissionPayloadDTO) {
           const newValue = new SubmissionPayloadDTO(value);
-          const result = await validator.validate(newValue as SubmissionPayloadDTO);
-          // Todo: Add logging here
-          return result.length === 0;
+          results = await validator.validate(newValue as SubmissionPayloadDTO);
+          return results.length === 0;
+        },
+        defaultMessage: () => {
+          const readableErrors = results.map(result => getNestedError(result));
+          return JSON.stringify(readableErrors);
         },
       },
     });
   };
 }
+
+// Recursive functions return any: https://github.com/microsoft/TypeScript/issues/21952#issue-297220945
+const getNestedError = (error: ValidationError): unknown => {
+  if (error.children && !error.constraints) {
+    return error.children.map(child => getNestedError(child));
+  }
+  return { [error.property]: error.constraints };
+};


### PR DESCRIPTION
- Fix error filter logging errors twice
- Fix error filter private keys implementation
- Fix LHA array validator naming
- Filter payload from error so we don't log PII
- Fix error logging parameters
- Use `defaultMessage` + `exceptionFactory` to expose validation error messages

![image](https://user-images.githubusercontent.com/71518072/148137581-a4b0a039-e878-45c1-b9d7-198059d19936.png)

I really hamfisted through this so I'm expecting some comments on how to clean this up a bit :\ also the response is heavily nested arrays which I think checks out because of the nested nature of our data, but maybe we can improve that as well