### PR TITLE
EHPR-192 | Fix specialty selector error message

### DIFF
--- a/packages/common/src/validators/is-array-of-specialties.decorator.ts
+++ b/packages/common/src/validators/is-array-of-specialties.decorator.ts
@@ -106,7 +106,7 @@ export class IsArrayOfSpecialties implements ValidatorConstraintInterface {
         if (!isValidString(subspecialty.id)) {
           return SpecialtyErrorEnum.SUBSPECIALTY_REQUIRED;
         }
-        if (subspecialtyNotListed(subspecialty, formSpecialties)) {
+        if (subspecialtyNotListed(subspecialty, formSubspecialties)) {
           return SpecialtyErrorEnum.INVALID_SUBSPECIALTY;
         }
       }


### PR DESCRIPTION
https://freshworks.atlassian.net/browse/EHPR-192

- We were accidentally passing the list of specialties instead of the current list of subspecialties to the `subspecialtyNotListed` method

![image](https://user-images.githubusercontent.com/71518072/148444321-b2688ae9-c5f9-4ea5-ab88-c67140c3ce2a.png)
