### PR TITLE
Remove NODE_ENV=development

### DIFF
--- a/.config/.env-example
+++ b/.config/.env-example
@@ -1,9 +1,6 @@
 # Project Info
 PROJECT=ehpr
 
-# Application
-# Runtime env setup development/test/production
-NODE_ENV=development
 # Application environment local/hosted
 RUNTIME_ENV=local
 

--- a/.github/workflows/pr-check-terraform.yml
+++ b/.github/workflows/pr-check-terraform.yml
@@ -6,7 +6,6 @@ on:
 
 env:
   PROJECT: ehpr
-  NODE_ENV: development
   ENV_NAME: dev
   TF_VERSION: 1.1.1
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ export PROJECT := $(or $(PROJECT),ehpr)
 
 
 # Runtime and application Environments specific variable
-export NODE_ENV ?= development
 export ENV_NAME ?= dev
 export POSTGRES_USERNAME = freshworks
 export CHES_CLIENT_ID ?= EHPR_SERVICE_CLIENT
@@ -169,8 +168,8 @@ build-api:
 
 build-web:
 	@echo "++\n***** Building Web for AWS\n++"
-	@NODE_ENV=production && yarn workspace @ehpr/web build
-	@NODE_ENV=production && yarn workspace @ehpr/web export
+	@yarn workspace @ehpr/web build
+	@yarn workspace @ehpr/web export
 	@mv ./apps/web/out ./terraform/build/app
 	@echo "++\n*****"
 

--- a/apps/api/env.js
+++ b/apps/api/env.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const NonLocalEnvironments = ['docker', 'remote'];
-const NodeEnv = process.env.NODE_ENV || 'development';
+const NodeEnv = process.env.NODE_ENV;
 if (!NonLocalEnvironments.includes(NodeEnv)) {
   require('dotenv').config({ path: path.resolve(__dirname, '../../.env') });
 }

--- a/apps/api/src/database/database.module.ts
+++ b/apps/api/src/database/database.module.ts
@@ -5,7 +5,7 @@ import { PostgresConnectionOptions } from 'typeorm/driver/postgres/PostgresConne
 
 import config from '../ormconfig';
 
-const nodeEnv = process.env.NODE_ENV || 'development';
+const nodeEnv = process.env.NODE_ENV;
 const entitiesPath =
   nodeEnv === 'production' ? join(__dirname, '../**/*.entity.js') : 'dist/**/*.entity.js';
 const migrationPath =

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,7 +65,6 @@ services:
       - '3000:3000'
     environment:
       - NEXT_PUBLIC_API_URL=http://localhost:4000/api/v1
-      - NODE_ENV=development
       - RUNTIME_ENV=local
     depends_on:
       - api


### PR DESCRIPTION
I think `NODE_ENV=development` is an anti-pattern and it's adding a bit of confusion, let's discuss these changes and merge if it's an improvement