### PR TITLE
EHPR-186 | Integration tests

### DIFF
--- a/.github/workflows/pr-check-api.yml
+++ b/.github/workflows/pr-check-api.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Install dependencies
         run: yarn workspace @ehpr/api install
 
+      - name: Integration test API Package
+        run: make api-integration-test-ci
+
       - name: Run formatting check
         run: yarn format:check
 
@@ -33,9 +36,6 @@ jobs:
 
       - name: Unit test API Package
         run: yarn workspace @ehpr/api test
-
-      - name: Integration test API Package
-        run: make api-integration-test-ci
 
       - name: Build API Package
         run: yarn workspace @ehpr/api build

--- a/.github/workflows/pr-check-api.yml
+++ b/.github/workflows/pr-check-api.yml
@@ -35,9 +35,7 @@ jobs:
         run: yarn workspace @ehpr/api test
 
       - name: Integration test API Package
-        run: make start-local-db \
-          make api-integration-test \
-          make stop-local-db
+        run: make api-integration-test-ci
 
       - name: Build API Package
         run: yarn workspace @ehpr/api build

--- a/.github/workflows/pr-check-api.yml
+++ b/.github/workflows/pr-check-api.yml
@@ -22,9 +22,6 @@ jobs:
       - name: Install dependencies
         run: yarn workspace @ehpr/api install
 
-      - name: Integration test API Package
-        run: make api-integration-test-ci
-
       - name: Run formatting check
         run: yarn format:check
 
@@ -36,6 +33,9 @@ jobs:
 
       - name: Unit test API Package
         run: yarn workspace @ehpr/api test
+
+      - name: Integration test API Package
+        run: make api-integration-test-ci
 
       - name: Build API Package
         run: yarn workspace @ehpr/api build

--- a/.github/workflows/pr-check-api.yml
+++ b/.github/workflows/pr-check-api.yml
@@ -35,7 +35,7 @@ jobs:
         run: yarn workspace @ehpr/api test
 
       - name: Integration test API Package
-        run: make api-integration-test-ci
+        run: make api-integration-test
 
       - name: Build API Package
         run: yarn workspace @ehpr/api build

--- a/.github/workflows/pr-check-api.yml
+++ b/.github/workflows/pr-check-api.yml
@@ -35,7 +35,9 @@ jobs:
         run: yarn workspace @ehpr/api test
 
       - name: Integration test API Package
-        run: yarn workspace @ehpr/api test
+        run: make start-local-db \
+          make api-integration-test \
+          make stop-local-db
 
       - name: Build API Package
         run: yarn workspace @ehpr/api build

--- a/.github/workflows/pr-check-api.yml
+++ b/.github/workflows/pr-check-api.yml
@@ -31,7 +31,10 @@ jobs:
       - name: Lint API Package
         run: yarn workspace @ehpr/api lint
 
-      - name: Test API Package
+      - name: Unit test API Package
+        run: yarn workspace @ehpr/api test
+
+      - name: Integration test API Package
         run: yarn workspace @ehpr/api test
 
       - name: Build API Package

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,13 @@ export POSTGRES_USERNAME = freshworks
 export CHES_CLIENT_ID ?= EHPR_SERVICE_CLIENT
 export MAIL_FROM ?= EHPRDoNotReply@gov.bc.ca
 
+# Integration testing variables
+TEST_POSTGRES_HOST := localhost
+TEST_POSTGRES_USERNAME := freshworks
+TEST_POSTGRES_PASSWORD := password
+TEST_POSTGRES_DATABASE := ehpr_test
+TEST_POSTGRES_PORT := 5433
+
 # Git
 export COMMIT_SHA:=$(shell git rev-parse --short=7 HEAD)
 export LAST_COMMIT_MESSAGE:=$(shell git log -1 --oneline --decorate=full --no-color --format="%h, %cn, %f, %D" | sed 's/->/:/')
@@ -137,25 +144,23 @@ docker-run:
 
 api-unit-test:
 	@echo "++\n***** Running API unit tests\n++"
-	@yarn workspace @ehpr/common build
 	@yarn workspace @ehpr/api build
 	@yarn workspace @ehpr/api test
 	@echo "++\n*****"
 
-start-local-db:
+start-test-db:
 	NODE_ENV=test docker-compose -f docker-compose.test.yaml up --build -d
 
-stop-local-db:
+stop-test-db:
 	NODE_ENV=test docker-compose -f docker-compose.test.yaml down
 
 api-integration-test:
 	@echo "++\n***** Running API integration tests\n++"
-	@yarn workspace @ehpr/common build
 	@yarn workspace @ehpr/api build
 	@yarn workspace @ehpr/api test:e2e
 	@echo "++\n*****"
 
-api-integration-test-ci: start-local-db api-integration-test stop-local-db
+api-integration-test-ci: start-test-db api-integration-test stop-test-db
 
 
 # Build application stack

--- a/Makefile
+++ b/Makefile
@@ -154,13 +154,13 @@ start-test-db:
 stop-test-db:
 	NODE_ENV=test docker-compose -f docker-compose.test.yaml down
 
-api-integration-test:
+api-integration-test: 
+	@make start-test-db 
 	@echo "++\n***** Running API integration tests\n++"
 	@yarn workspace @ehpr/api build
 	@yarn workspace @ehpr/api test:e2e
 	@echo "++\n*****"
-
-api-integration-test-ci: start-test-db api-integration-test stop-test-db
+	@make stop-test-db
 
 
 # Build application stack

--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,26 @@ docker-run:
 	@docker-compose up --build
 	@echo "++\n*****"
 
+api-unit-test:
+	@echo "++\n***** Running API unit tests\n++"
+	@yarn workspace @ehpr/common build
+	@yarn workspace @ehpr/api build
+	@yarn workspace @ehpr/api test
+	@echo "++\n*****"
+
+start-local-db:
+	NODE_ENV=test docker-compose -f docker-compose.test.yaml up --build -d
+
+stop-local-db:
+	NODE_ENV=test docker-compose -f docker-compose.test.yaml down
+
+api-integration-test:
+	@echo "++\n***** Running API unit tests\n++"
+	@yarn workspace @ehpr/common build
+	@yarn workspace @ehpr/api build
+	@yarn workspace @ehpr/api test:e2e
+	@echo "++\n*****"
+
 
 # Build application stack
 

--- a/Makefile
+++ b/Makefile
@@ -149,11 +149,13 @@ stop-local-db:
 	NODE_ENV=test docker-compose -f docker-compose.test.yaml down
 
 api-integration-test:
-	@echo "++\n***** Running API unit tests\n++"
+	@echo "++\n***** Running API integration tests\n++"
 	@yarn workspace @ehpr/common build
 	@yarn workspace @ehpr/api build
 	@yarn workspace @ehpr/api test:e2e
 	@echo "++\n*****"
+
+api-integration-test-ci: start-local-db api-integration-test stop-local-db
 
 
 # Build application stack

--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,11 @@ export CHES_CLIENT_ID ?= EHPR_SERVICE_CLIENT
 export MAIL_FROM ?= EHPRDoNotReply@gov.bc.ca
 
 # Integration testing variables
-TEST_POSTGRES_HOST := localhost
-TEST_POSTGRES_USERNAME := freshworks
-TEST_POSTGRES_PASSWORD := password
-TEST_POSTGRES_DATABASE := ehpr_test
-TEST_POSTGRES_PORT := 5433
+export TEST_POSTGRES_HOST := localhost
+export TEST_POSTGRES_USERNAME := freshworks
+export TEST_POSTGRES_PASSWORD := password
+export TEST_POSTGRES_DATABASE := ehpr_test
+export TEST_POSTGRES_PORT := 5433
 
 # Git
 export COMMIT_SHA:=$(shell git rev-parse --short=7 HEAD)

--- a/README.md
+++ b/README.md
@@ -13,3 +13,17 @@ ie:
 # apps/web/.env.local
 NEXT_PUBLIC_API_URL=http://localhost:4000/api/v1
 ```
+
+## Tests
+
+Unit and integration tests are run against the API in the CI pipeline on pull request as well as deploy.
+
+### Running Locally
+
+#### API Unit Tests
+
+Run API unit tests with `api-unit-test`
+
+#### API Integration Tests
+
+Run API integration tests with `api-integration-test`

--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@ Unit and integration tests are run against the API in the CI pipeline on pull re
 
 #### API Unit Tests
 
-Run API unit tests with `api-unit-test`
+Run API unit tests with `make api-unit-test`
 
 #### API Integration Tests
 
-Run API integration tests with `api-integration-test`
+Run API integration tests with `make api-integration-test`
+
+This command will spin up a postgres container, run the API integration tests, then close the created container.

--- a/apps/api/jest-e2e.json
+++ b/apps/api/jest-e2e.json
@@ -1,9 +1,13 @@
 {
   "moduleFileExtensions": ["js", "json", "ts"],
-  "rootDir": ".",
+  "rootDir": "./",
   "testEnvironment": "node",
   "testRegex": ".e2e-spec.ts$",
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
+  },
+  "moduleDirectories": ["node_modules", "src"],
+  "moduleNameMapper": {
+    "src/(.*)": "<rootDir>/src/$1"
   }
 }

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -21,7 +21,7 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./jest-e2e.json",
+    "test:e2e": "NODE_ENV=test jest --config ./jest-e2e.json",
     "typeorm": "ts-node -r tsconfig-paths/register ../../node_modules/typeorm/cli.js --config src/ormconfig.ts"
   },
   "dependencies": {

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -21,7 +21,7 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "test:e2e": "jest --config ./jest-e2e.json",
     "typeorm": "ts-node -r tsconfig-paths/register ../../node_modules/typeorm/cli.js --config src/ormconfig.ts"
   },
   "dependencies": {
@@ -55,15 +55,14 @@
     "@nestjs/testing": "8.0.0",
     "@types/aws-lambda": "8.10.84",
     "@types/express": "4.17.13",
-    "@types/jest": "26.0.14",
     "@types/js-yaml": "4.0.5",
     "@types/node": "16.0.0",
     "@types/supertest": "2.0.11",
     "eslint": "8.0.1",
-    "jest": "26.6.0",
+    "jest": "27.4.7",
     "source-map-support": "0.5.20",
     "supertest": "6.1.3",
-    "ts-jest": "26.4.2",
+    "ts-jest": "27.1.2",
     "ts-loader": "9.2.3",
     "ts-node": "10.0.0",
     "tsconfig-paths": "3.10.1",
@@ -76,7 +75,7 @@
       "ts"
     ],
     "rootDir": "src",
-    "testRegex": ".*\\.spec\\.ts$",
+    "testRegex": ".\\**\\.spec\\.ts$",
     "transform": {
       ".+\\.(t|j)s$": "ts-jest"
     },

--- a/apps/api/src/app.config.ts
+++ b/apps/api/src/app.config.ts
@@ -55,11 +55,14 @@ export async function createNestApp(): Promise<{
       enableDebugMessages: false,
       disableErrorMessages: true,
       exceptionFactory: errors => {
-        const errorMessages = errors.map(error =>
-          error.constraints
-            ? JSON.parse(error.constraints.ValidateNestedObject)
-            : 'Validation Error Not Found',
-        );
+        const errorMessages = errors.map(error => {
+          const nestedValidationError = error.constraints?.ValidateNestedObject;
+          if (nestedValidationError) {
+            return JSON.parse(nestedValidationError);
+          }
+
+          return error.constraints;
+        });
         throw new BadRequestException(errorMessages);
       },
     }),

--- a/apps/api/src/app.config.ts
+++ b/apps/api/src/app.config.ts
@@ -1,5 +1,5 @@
 import { NestFactory } from '@nestjs/core';
-import { BadRequestException, ValidationPipe } from '@nestjs/common';
+import { BadRequestException, ValidationPipe, ValidationPipeOptions } from '@nestjs/common';
 import { ExpressAdapter, NestExpressApplication } from '@nestjs/platform-express';
 import express from 'express';
 
@@ -10,6 +10,25 @@ import { SuccessResponseInterceptor } from './common/interceptors/success-respon
 import { ErrorExceptionFilter } from './common/error-exception.filter';
 import { TrimPipe } from './common/trim.pipe';
 import { API_PREFIX } from './config';
+
+export const validationPipeConfig: ValidationPipeOptions = {
+  transform: true,
+  whitelist: true,
+  forbidNonWhitelisted: false,
+  enableDebugMessages: false,
+  disableErrorMessages: true,
+  exceptionFactory: errors => {
+    const errorMessages = errors.map(error => {
+      const nestedValidationError = error.constraints?.ValidateNestedObject;
+      if (nestedValidationError) {
+        return JSON.parse(nestedValidationError);
+      }
+
+      return error.constraints;
+    });
+    throw new BadRequestException(errorMessages);
+  },
+};
 
 export async function createNestApp(): Promise<{
   app: NestExpressApplication;
@@ -46,27 +65,7 @@ export async function createNestApp(): Promise<{
   app.useGlobalInterceptors(new SuccessResponseInterceptor());
 
   // Validation pipe
-  app.useGlobalPipes(
-    new TrimPipe(),
-    new ValidationPipe({
-      transform: true,
-      whitelist: true,
-      forbidNonWhitelisted: false,
-      enableDebugMessages: false,
-      disableErrorMessages: true,
-      exceptionFactory: errors => {
-        const errorMessages = errors.map(error => {
-          const nestedValidationError = error.constraints?.ValidateNestedObject;
-          if (nestedValidationError) {
-            return JSON.parse(nestedValidationError);
-          }
-
-          return error.constraints;
-        });
-        throw new BadRequestException(errorMessages);
-      },
-    }),
-  );
+  app.useGlobalPipes(new TrimPipe(), new ValidationPipe(validationPipeConfig));
 
   // Global Error Filter
   app.useGlobalFilters(new ErrorExceptionFilter(app.get(AppLogger)));

--- a/apps/api/src/database/database.module.ts
+++ b/apps/api/src/database/database.module.ts
@@ -1,23 +1,46 @@
 import { Module, Logger } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { join } from 'path';
+import { LoggerOptions } from 'typeorm';
 import { PostgresConnectionOptions } from 'typeorm/driver/postgres/PostgresConnectionOptions';
 
 import config from '../ormconfig';
 
+const getEnvironmentSpecificConfig = (env?: string) => {
+  switch (env) {
+    case 'production':
+      return {
+        entitiesPath: join(__dirname, '../**/*.entity.js'),
+        migrationPath: join(__dirname, '../migration/*.js'),
+        logging: ['migration'],
+      };
+    case 'test':
+      return {
+        host: 'localhost',
+        entitiesPath: 'src/**/*.entity.ts',
+        migrationPath: 'src/migration/*.js',
+        logging: ['error', 'warn', 'migration'],
+      };
+    default:
+      return {
+        entitiesPath: 'dist/**/*.entity.js',
+        migrationPath: 'dist/migration/*.js',
+        logging: ['error', 'warn', 'migration'],
+      };
+  }
+};
+
 const nodeEnv = process.env.NODE_ENV;
-const entitiesPath =
-  nodeEnv === 'production' ? join(__dirname, '../**/*.entity.js') : 'dist/**/*.entity.js';
-const migrationPath =
-  nodeEnv === 'production' ? join(__dirname, '../migration/*.js') : 'dist/migration/*.js';
+const environmentSpecificConfig = getEnvironmentSpecificConfig(nodeEnv);
 
 const appOrmConfig: PostgresConnectionOptions = {
   ...config,
-  migrations: [migrationPath],
-  entities: [entitiesPath],
+  host: environmentSpecificConfig.host ? environmentSpecificConfig.host : config.host,
+  migrations: [environmentSpecificConfig.migrationPath],
+  entities: [environmentSpecificConfig.entitiesPath],
   synchronize: false,
   migrationsRun: true,
-  logging: process.env.TARGET_ENV === 'prod' ? ['migration'] : ['error', 'warn', 'migration'],
+  logging: environmentSpecificConfig.logging as LoggerOptions,
 };
 @Module({
   imports: [TypeOrmModule.forRoot(appOrmConfig)],

--- a/apps/api/src/database/database.module.ts
+++ b/apps/api/src/database/database.module.ts
@@ -17,6 +17,7 @@ const getEnvironmentSpecificConfig = (env?: string) => {
     case 'test':
       return {
         host: 'localhost',
+        database: 'test-db',
         entitiesPath: 'src/**/*.entity.ts',
         migrationPath: 'src/migration/*.js',
         logging: ['error', 'warn', 'migration'],

--- a/apps/api/src/mail/mail.service.ts
+++ b/apps/api/src/mail/mail.service.ts
@@ -22,7 +22,10 @@ export class MailService {
    * @param mailOptions - Email to be sent
    * @returns A promise for the result of sending the email
    */
-  public async sendMailWithChes(mailOptions: MailOptions): Promise<ChesResponse> {
+  public async sendMailWithChes(mailOptions: MailOptions): Promise<ChesResponse | void> {
+    const chesHost = process.env.CHES_SERVICE_HOST;
+    if (!chesHost) return;
+
     const emailBody = {
       from: mailOptions.from,
       to: mailOptions.to,
@@ -75,7 +78,7 @@ export class MailService {
    * @returns A promise for the result of sending the email
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public async sendMailable(mailable: Mailable<any>): Promise<ChesResponse> {
+  public async sendMailable(mailable: Mailable<any>): Promise<ChesResponse | void> {
     const mailOptions: Partial<MailOptions> = {
       from: process.env.MAIL_FROM,
       to: [mailable.recipient.email],

--- a/apps/api/src/submission/submission.service.ts
+++ b/apps/api/src/submission/submission.service.ts
@@ -45,8 +45,8 @@ export class SubmissionService {
       `Sending confirmation email for submission: ${submission.id}`,
       SubmissionService.name,
     );
-    const { txId } = await this.mailService.sendMailable(mailable);
-    submission.chesId = txId;
+    const mailResponse = await this.mailService.sendMailable(mailable);
+    submission.chesId = mailResponse?.txId;
     submission = await this.submissionRepository.save(submission);
     this.logger.log(
       `Confirmation email sent for submission: ${submission.id}`,

--- a/apps/api/test/app.e2e-spec.ts
+++ b/apps/api/test/app.e2e-spec.ts
@@ -1,6 +1,8 @@
+require('../env');
+import request from 'supertest';
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
-import * as request from 'supertest';
+
 import { AppModule } from '../src/app.module';
 
 describe('AppController (e2e)', () => {
@@ -15,7 +17,20 @@ describe('AppController (e2e)', () => {
     await app.init();
   });
 
-  it('/ (GET)', () => {
-    return request(app.getHttpServer()).get('/').expect(200).expect('Hello World!');
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('/version (GET)', done => {
+    return request(app.getHttpServer())
+      .get('/version')
+      .expect(res => {
+        const { body } = res;
+        expect(body.buildId).toBeDefined();
+        expect(body.info).toBeDefined();
+        expect(body.env).toBeDefined();
+      })
+      .expect(200)
+      .end(done);
   });
 });

--- a/apps/api/test/app.e2e-spec.ts
+++ b/apps/api/test/app.e2e-spec.ts
@@ -22,7 +22,7 @@ describe('AppController (e2e)', () => {
   });
 
   it('/version (GET)', done => {
-    return request(app.getHttpServer())
+    request(app.getHttpServer())
       .get('/version')
       .expect(res => {
         const { body } = res;

--- a/apps/api/test/fixture/invalidSubmission_firstname.json
+++ b/apps/api/test/fixture/invalidSubmission_firstname.json
@@ -1,0 +1,50 @@
+{
+  "payload": {
+    "personalInformation": {
+      "firstName": "",
+      "lastName": "User",
+      "postalCode": "A3A3A3"
+    },
+    "contactInformation": {
+      "primaryPhone": "5284561234",
+      "email": "test@test.io"
+    },
+    "skillInformation": {
+      "stream": "Midwife",
+      "registrationStatus": "notRegistered",
+      "registrationNumber": "321321",
+      "currentEmployment": "healthSectorEmployed",
+      "specialties": [
+        {
+          "id": null,
+          "subspecialties": []
+        }
+      ],
+      "healthAuthorities": ["firstNationsHa"],
+      "employmentCircumstance": null
+    },
+    "availabilityInformation": {
+      "deployAnywhere": false,
+      "deploymentLocations": [
+        "Hope",
+        "Chilliwack",
+        "Abbotsford",
+        "Mission",
+        "AgassizHarrison",
+        "NewWestminster",
+        "Burnaby",
+        "MapleRidgePittMeadows",
+        "TriCities",
+        "Langley",
+        "Delta",
+        "Surrey",
+        "SouthSurreyWhiteRock"
+      ],
+      "placementOptions": ["other", "anywhere"],
+      "hasImmunizationTraining": true,
+      "deploymentDuration": "twoToFour"
+    },
+    "confirm": true
+  },
+  "version": "v1"
+}

--- a/apps/api/test/fixture/validSubmission.json
+++ b/apps/api/test/fixture/validSubmission.json
@@ -1,0 +1,50 @@
+{
+  "payload": {
+    "personalInformation": {
+      "firstName": "Test",
+      "lastName": "User",
+      "postalCode": "A3A3A3"
+    },
+    "contactInformation": {
+      "primaryPhone": "5284561234",
+      "email": "test@test.io"
+    },
+    "skillInformation": {
+      "stream": "Midwife",
+      "registrationStatus": "notRegistered",
+      "registrationNumber": "321321",
+      "currentEmployment": "healthSectorEmployed",
+      "specialties": [
+        {
+          "id": null,
+          "subspecialties": []
+        }
+      ],
+      "healthAuthorities": ["firstNationsHa"],
+      "employmentCircumstance": null
+    },
+    "availabilityInformation": {
+      "deployAnywhere": false,
+      "deploymentLocations": [
+        "Hope",
+        "Chilliwack",
+        "Abbotsford",
+        "Mission",
+        "AgassizHarrison",
+        "NewWestminster",
+        "Burnaby",
+        "MapleRidgePittMeadows",
+        "TriCities",
+        "Langley",
+        "Delta",
+        "Surrey",
+        "SouthSurreyWhiteRock"
+      ],
+      "placementOptions": ["other", "anywhere"],
+      "hasImmunizationTraining": true,
+      "deploymentDuration": "twoToFour"
+    },
+    "confirm": true
+  },
+  "version": "v1"
+}

--- a/apps/api/test/submission.e2e-spec.ts
+++ b/apps/api/test/submission.e2e-spec.ts
@@ -1,0 +1,65 @@
+require('../env');
+import request from 'supertest';
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+
+import { AppModule } from '../src/app.module';
+
+import validSubmissionData from './fixture/validSubmission.json';
+import invalidSubmissionDataFirstname from './fixture/invalidSubmission_firstname.json';
+import { validationPipeConfig } from 'src/app.config';
+
+describe('AppController (e2e)', () => {
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+
+    app.useGlobalPipes(new ValidationPipe(validationPipeConfig));
+
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('successfully saves a valid submission', done => {
+    request(app.getHttpServer())
+      .post(`/submission`)
+      .send(validSubmissionData)
+      .expect(res => {
+        const { body } = res;
+        expect(body.confirmationId).toBeDefined();
+        expect(body.id).toBeDefined();
+      })
+      .expect(201)
+      .end(done);
+  });
+
+  it('returns a validation error for blank firstName', done => {
+    request(app.getHttpServer())
+      .post(`/submission`)
+      .send(invalidSubmissionDataFirstname)
+      .expect(res => {
+        const { body } = res;
+
+        expect(body.statusCode).toBe(400);
+        expect(body.error).toBe('Bad Request');
+
+        const errorObject = body.message[0][0][0];
+
+        expect(errorObject.firstName.matches).toBe('First Name is Required');
+        expect(errorObject.firstName.isNotEmpty).toBe('First Name is Required');
+        expect(errorObject.firstName.isLength).toBe(
+          'First Name must be between 1 and 255 characters',
+        );
+      })
+      .expect(400)
+      .end(done);
+  });
+});

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -2,7 +2,11 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "baseUrl": "./"
+    "baseUrl": "./",
+    "allowJs": true
   },
-  "exclude": ["node_modules", "dist", "**/*.spec.ts"]
+  "paths": {
+    "src": "./src"
+  },
+  "exclude": ["node_modules", "dist", "**/*.spec.ts", "./env.js"]
 }

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -3,12 +3,10 @@ services:
   test-db:
     image: postgres:13-alpine
     container_name: ${PROJECT}_test_db
-    volumes:
-      - ./.pgdata:/var/lib/postgresql/data
     ports:
-      - '5432:5432'
+      - '5433:5432'
     environment:
-      - POSTGRES_USER=${POSTGRES_USERNAME}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-      - POSTGRES_DB=${PROJECT}
+      - POSTGRES_USER=${TEST_POSTGRES_USERNAME}
+      - POSTGRES_PASSWORD=${TEST_POSTGRES_PASSWORD}
+      - POSTGRES_DB=${TEST_POSTGRES_DATABASE}
     restart: always

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -1,8 +1,8 @@
 version: '3.8'
 services:
-  db:
+  test-db:
     image: postgres:13-alpine
-    container_name: ${PROJECT}_db
+    container_name: ${PROJECT}_test_db
     volumes:
       - ./.pgdata:/var/lib/postgresql/data
     ports:

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -1,0 +1,14 @@
+version: '3.8'
+services:
+  db:
+    image: postgres:13-alpine
+    container_name: ${PROJECT}_db
+    volumes:
+      - ./.pgdata:/var/lib/postgresql/data
+    ports:
+      - '5432:5432'
+    environment:
+      - POSTGRES_USER=${POSTGRES_USERNAME}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=${PROJECT}
+    restart: always

--- a/yarn.lock
+++ b/yarn.lock
@@ -121,7 +121,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/compat-data@npm:^7.16.0":
+"@babel/code-frame@npm:^7.16.7":
+  version: 7.16.7
+  resolution: "@babel/code-frame@npm:7.16.7"
+  dependencies:
+    "@babel/highlight": ^7.16.7
+  checksum: db2f7faa31bc2c9cf63197b481b30ea57147a5fc1a6fab60e5d6c02cdfbf6de8e17b5121f99917b3dabb5eeb572da078312e70697415940383efc140d4e0808b
+  languageName: node
+  linkType: hard
+
+"@babel/compat-data@npm:^7.16.0, @babel/compat-data@npm:^7.16.4":
   version: 7.16.4
   resolution: "@babel/compat-data@npm:7.16.4"
   checksum: 4949ce54eafc4b38d5623696a872acaaced1a523605708d81c2c483253941917d90dae0de40fc01e152ae56075dadd89c23014da5a632b09c001a716fa689cae
@@ -151,6 +160,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/core@npm:^7.8.0":
+  version: 7.16.7
+  resolution: "@babel/core@npm:7.16.7"
+  dependencies:
+    "@babel/code-frame": ^7.16.7
+    "@babel/generator": ^7.16.7
+    "@babel/helper-compilation-targets": ^7.16.7
+    "@babel/helper-module-transforms": ^7.16.7
+    "@babel/helpers": ^7.16.7
+    "@babel/parser": ^7.16.7
+    "@babel/template": ^7.16.7
+    "@babel/traverse": ^7.16.7
+    "@babel/types": ^7.16.7
+    convert-source-map: ^1.7.0
+    debug: ^4.1.0
+    gensync: ^1.0.0-beta.2
+    json5: ^2.1.2
+    semver: ^6.3.0
+    source-map: ^0.5.0
+  checksum: 3206e077e76db189726c4da19a5296eae11c6c1f5abea7013e74f18708bb91616914717ff8d8ca466cc0ba9d2d2147e9a84c3c357b9ad4cba601da14107838ed
+  languageName: node
+  linkType: hard
+
 "@babel/generator@npm:^7.16.0, @babel/generator@npm:^7.7.2":
   version: 7.16.0
   resolution: "@babel/generator@npm:7.16.0"
@@ -159,6 +191,17 @@ __metadata:
     jsesc: ^2.5.1
     source-map: ^0.5.0
   checksum: 9ff53e0db72a225c8783c4a277698b4efcead750542ebb9cff31732ba62d092090715a772df10a323446924712f6928ad60c03db4e7051bed3a9701b552d51fb
+  languageName: node
+  linkType: hard
+
+"@babel/generator@npm:^7.16.7":
+  version: 7.16.7
+  resolution: "@babel/generator@npm:7.16.7"
+  dependencies:
+    "@babel/types": ^7.16.7
+    jsesc: ^2.5.1
+    source-map: ^0.5.0
+  checksum: 20c6a7c5e372a66ec2900c074b2ec3634d3f615cafccbb416770f4b419251c6dc27a0a137b71407e218463fe059a3a6a5afb734f35089d94bdb66e01fe8a9e6f
   languageName: node
   linkType: hard
 
@@ -176,6 +219,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-compilation-targets@npm:^7.16.7":
+  version: 7.16.7
+  resolution: "@babel/helper-compilation-targets@npm:7.16.7"
+  dependencies:
+    "@babel/compat-data": ^7.16.4
+    "@babel/helper-validator-option": ^7.16.7
+    browserslist: ^4.17.5
+    semver: ^6.3.0
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 7238aaee78c011a42fb5ca92e5eff098752f7b314c2111d7bb9cdd58792fcab1b9c819b59f6a0851dc210dc09dc06b30d130a23982753e70eb3111bc65204842
+  languageName: node
+  linkType: hard
+
+"@babel/helper-environment-visitor@npm:^7.16.7":
+  version: 7.16.7
+  resolution: "@babel/helper-environment-visitor@npm:7.16.7"
+  dependencies:
+    "@babel/types": ^7.16.7
+  checksum: c03a10105d9ebd1fe632a77356b2e6e2f3c44edba9a93b0dc3591b6a66bd7a2e323dd9502f9ce96fc6401234abff1907aa877b6674f7826b61c953f7c8204bbe
+  languageName: node
+  linkType: hard
+
 "@babel/helper-function-name@npm:^7.16.0":
   version: 7.16.0
   resolution: "@babel/helper-function-name@npm:7.16.0"
@@ -184,6 +250,17 @@ __metadata:
     "@babel/template": ^7.16.0
     "@babel/types": ^7.16.0
   checksum: 8c02371d28678f3bb492e69d4635b2fe6b1c5a93ce129bf883f1fafde2005f4dbc0e643f52103ca558b698c0774bfb84a93f188d71db1c077f754b6220629b92
+  languageName: node
+  linkType: hard
+
+"@babel/helper-function-name@npm:^7.16.7":
+  version: 7.16.7
+  resolution: "@babel/helper-function-name@npm:7.16.7"
+  dependencies:
+    "@babel/helper-get-function-arity": ^7.16.7
+    "@babel/template": ^7.16.7
+    "@babel/types": ^7.16.7
+  checksum: fc77cbe7b10cfa2a262d7a37dca575c037f20419dfe0c5d9317f589599ca24beb5f5c1057748011159149eaec47fe32338c6c6412376fcded68200df470161e1
   languageName: node
   linkType: hard
 
@@ -196,12 +273,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-get-function-arity@npm:^7.16.7":
+  version: 7.16.7
+  resolution: "@babel/helper-get-function-arity@npm:7.16.7"
+  dependencies:
+    "@babel/types": ^7.16.7
+  checksum: 25d969fb207ff2ad5f57a90d118f6c42d56a0171022e200aaa919ba7dc95ae7f92ec71cdea6c63ef3629a0dc962ab4c78e09ca2b437185ab44539193f796e0c3
+  languageName: node
+  linkType: hard
+
 "@babel/helper-hoist-variables@npm:^7.16.0":
   version: 7.16.0
   resolution: "@babel/helper-hoist-variables@npm:7.16.0"
   dependencies:
     "@babel/types": ^7.16.0
   checksum: 2ee5b400c267c209a53c90eea406a8f09c30d4d7a2b13e304289d858a2e34a99272c062cfad6dad63705662943951c42ff20042ef539b2d3c4f8743183a28954
+  languageName: node
+  linkType: hard
+
+"@babel/helper-hoist-variables@npm:^7.16.7":
+  version: 7.16.7
+  resolution: "@babel/helper-hoist-variables@npm:7.16.7"
+  dependencies:
+    "@babel/types": ^7.16.7
+  checksum: 6ae1641f4a751cd9045346e3f61c3d9ec1312fd779ab6d6fecfe2a96e59a481ad5d7e40d2a840894c13b3fd6114345b157f9e3062fc5f1580f284636e722de60
   languageName: node
   linkType: hard
 
@@ -223,6 +318,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-module-imports@npm:^7.16.7":
+  version: 7.16.7
+  resolution: "@babel/helper-module-imports@npm:7.16.7"
+  dependencies:
+    "@babel/types": ^7.16.7
+  checksum: ddd2c4a600a2e9a4fee192ab92bf35a627c5461dbab4af31b903d9ba4d6b6e59e0ff3499fde4e2e9a0eebe24906f00b636f8b4d9bd72ff24d50e6618215c3212
+  languageName: node
+  linkType: hard
+
 "@babel/helper-module-transforms@npm:^7.16.0":
   version: 7.16.0
   resolution: "@babel/helper-module-transforms@npm:7.16.0"
@@ -236,6 +340,22 @@ __metadata:
     "@babel/traverse": ^7.16.0
     "@babel/types": ^7.16.0
   checksum: a3d0e5556f26ebdf2ae422af3b9a1ba1848fead891f46bcd1c6a4be88ad8e9f348140f81d1843a3481574be1643a9c79b01469231f5b5801f5d5e691efdd11f3
+  languageName: node
+  linkType: hard
+
+"@babel/helper-module-transforms@npm:^7.16.7":
+  version: 7.16.7
+  resolution: "@babel/helper-module-transforms@npm:7.16.7"
+  dependencies:
+    "@babel/helper-environment-visitor": ^7.16.7
+    "@babel/helper-module-imports": ^7.16.7
+    "@babel/helper-simple-access": ^7.16.7
+    "@babel/helper-split-export-declaration": ^7.16.7
+    "@babel/helper-validator-identifier": ^7.16.7
+    "@babel/template": ^7.16.7
+    "@babel/traverse": ^7.16.7
+    "@babel/types": ^7.16.7
+  checksum: 6e930ce776c979f299cdbeaf80187f4ab086d75287b96ecc1c6896d392fcb561065f0d6219fc06fa79b4ceb4bbdc1a9847da8099aba9b077d0a9e583500fb673
   languageName: node
   linkType: hard
 
@@ -276,12 +396,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-simple-access@npm:^7.16.7":
+  version: 7.16.7
+  resolution: "@babel/helper-simple-access@npm:7.16.7"
+  dependencies:
+    "@babel/types": ^7.16.7
+  checksum: 8d22c46c5ec2ead0686c4d5a3d1d12b5190c59be676bfe0d9d89df62b437b51d1a3df2ccfb8a77dded2e585176ebf12986accb6d45a18cff229eef3b10344f4b
+  languageName: node
+  linkType: hard
+
 "@babel/helper-split-export-declaration@npm:^7.16.0":
   version: 7.16.0
   resolution: "@babel/helper-split-export-declaration@npm:7.16.0"
   dependencies:
     "@babel/types": ^7.16.0
   checksum: 8bd87b5ea2046b145f0f55bc75cbdb6df69eaeb32919ee3c1c758757025aebca03e567a4d48389eb4f16a55021adb6ed8fa58aa771e164b15fa5e0a0722f771d
+  languageName: node
+  linkType: hard
+
+"@babel/helper-split-export-declaration@npm:^7.16.7":
+  version: 7.16.7
+  resolution: "@babel/helper-split-export-declaration@npm:7.16.7"
+  dependencies:
+    "@babel/types": ^7.16.7
+  checksum: e10aaf135465c55114627951b79115f24bc7af72ecbb58d541d66daf1edaee5dde7cae3ec8c3639afaf74526c03ae3ce723444e3b5b3dc77140c456cd84bcaa1
   languageName: node
   linkType: hard
 
@@ -292,10 +430,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-validator-identifier@npm:^7.16.7":
+  version: 7.16.7
+  resolution: "@babel/helper-validator-identifier@npm:7.16.7"
+  checksum: dbb3db9d184343152520a209b5684f5e0ed416109cde82b428ca9c759c29b10c7450657785a8b5c5256aa74acc6da491c1f0cf6b784939f7931ef82982051b69
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-option@npm:^7.14.5":
   version: 7.14.5
   resolution: "@babel/helper-validator-option@npm:7.14.5"
   checksum: 1b25c34a5cb3d8602280f33b9ab687d2a77895e3616458d0f70ddc450ada9b05e342c44f322bc741d51b252e84cff6ec44ae93d622a3354828579a643556b523
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-option@npm:^7.16.7":
+  version: 7.16.7
+  resolution: "@babel/helper-validator-option@npm:7.16.7"
+  checksum: c5ccc451911883cc9f12125d47be69434f28094475c1b9d2ada7c3452e6ac98a1ee8ddd364ca9e3f9855fcdee96cdeafa32543ebd9d17fee7a1062c202e80570
   languageName: node
   linkType: hard
 
@@ -310,6 +462,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helpers@npm:^7.16.7":
+  version: 7.16.7
+  resolution: "@babel/helpers@npm:7.16.7"
+  dependencies:
+    "@babel/template": ^7.16.7
+    "@babel/traverse": ^7.16.7
+    "@babel/types": ^7.16.7
+  checksum: 75504c76b66a29b91f954fcc0867dfe275a4cfba5b44df6d64405df74ea72f967fccfa63d62c31c423c5502d113290000c581e0e4858a214f0303d7ecf55c29f
+  languageName: node
+  linkType: hard
+
 "@babel/highlight@npm:^7.10.4, @babel/highlight@npm:^7.16.0":
   version: 7.16.0
   resolution: "@babel/highlight@npm:7.16.0"
@@ -321,12 +484,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/highlight@npm:^7.16.7":
+  version: 7.16.7
+  resolution: "@babel/highlight@npm:7.16.7"
+  dependencies:
+    "@babel/helper-validator-identifier": ^7.16.7
+    chalk: ^2.0.0
+    js-tokens: ^4.0.0
+  checksum: f7e04e7e03b83c2cca984f4d3e180c9b018784f45d03367e94daf983861229ddc47264045f3b58dfeb0007f9c67bc2a76c4de1693bad90e5394876ef55ece5bb
+  languageName: node
+  linkType: hard
+
 "@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.16.0, @babel/parser@npm:^7.16.3, @babel/parser@npm:^7.7.2":
   version: 7.16.4
   resolution: "@babel/parser@npm:7.16.4"
   bin:
     parser: ./bin/babel-parser.js
   checksum: ce0a8f92f440f2a12bc932f070a7b60c5133bf8a63f461841f9e39af0194f573707959d606c6fad1a2fd496a45148553afd9b74d3b8dd36cdb7861598d1f3e36
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.16.7":
+  version: 7.16.7
+  resolution: "@babel/parser@npm:7.16.7"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: e664ff1edda164ab3f3c97fc1dd1a8930b0fba9981cbf873d3f25a22d16d50e2efcfaf81daeefa978bff2c4f268d34832f6817c8bc4e03594c3f43beba92fb68
   languageName: node
   linkType: hard
 
@@ -523,6 +706,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/template@npm:^7.16.7":
+  version: 7.16.7
+  resolution: "@babel/template@npm:7.16.7"
+  dependencies:
+    "@babel/code-frame": ^7.16.7
+    "@babel/parser": ^7.16.7
+    "@babel/types": ^7.16.7
+  checksum: 10cd112e89276e00f8b11b55a51c8b2f1262c318283a980f4d6cdb0286dc05734b9aaeeb9f3ad3311900b09bc913e02343fcaa9d4a4f413964aaab04eb84ac4a
+  languageName: node
+  linkType: hard
+
 "@babel/traverse@npm:^7.1.0, @babel/traverse@npm:^7.16.0, @babel/traverse@npm:^7.16.3, @babel/traverse@npm:^7.7.2":
   version: 7.16.3
   resolution: "@babel/traverse@npm:7.16.3"
@@ -537,6 +731,24 @@ __metadata:
     debug: ^4.1.0
     globals: ^11.1.0
   checksum: abb14857b1104c73124612954865e28f95a86eb6741f35851369b4f9eabc17e394c9aa6f21fba6ce23813592353090d409772be828717cbe5154a5e981a753c1
+  languageName: node
+  linkType: hard
+
+"@babel/traverse@npm:^7.16.7":
+  version: 7.16.7
+  resolution: "@babel/traverse@npm:7.16.7"
+  dependencies:
+    "@babel/code-frame": ^7.16.7
+    "@babel/generator": ^7.16.7
+    "@babel/helper-environment-visitor": ^7.16.7
+    "@babel/helper-function-name": ^7.16.7
+    "@babel/helper-hoist-variables": ^7.16.7
+    "@babel/helper-split-export-declaration": ^7.16.7
+    "@babel/parser": ^7.16.7
+    "@babel/types": ^7.16.7
+    debug: ^4.1.0
+    globals: ^11.1.0
+  checksum: 65261f7a5bf257c10a9415b6c227fb555ace359ad786645d9cf22f0e3fc8dc8e38895269f3b93cc39eccd8ed992e7bacc358b4cb7d3496fe54f91cda49220834
   languageName: node
   linkType: hard
 
@@ -557,6 +769,16 @@ __metadata:
     "@babel/helper-validator-identifier": ^7.15.7
     to-fast-properties: ^2.0.0
   checksum: 5b483da5c6e6f2394fba7ee1da8787a0c9cddd33491271c4da702e49e6faf95ce41d7c8bf9a4ee47f2ef06bdb35096f4d0f6ae4b5bea35ebefe16309d22344b7
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.16.7":
+  version: 7.16.7
+  resolution: "@babel/types@npm:7.16.7"
+  dependencies:
+    "@babel/helper-validator-identifier": ^7.16.7
+    to-fast-properties: ^2.0.0
+  checksum: df9210723259df9faea8c7e5674a59e57ead82664aab9f54daae887db5a50a956f30f57ed77a2d6cbb89b908d520cf8d883267c4e9098e31bc74649f2f714654
   languageName: node
   linkType: hard
 
@@ -621,7 +843,6 @@ __metadata:
     "@nestjs/typeorm": 8.0.2
     "@types/aws-lambda": 8.10.84
     "@types/express": 4.17.13
-    "@types/jest": 26.0.14
     "@types/js-yaml": 4.0.5
     "@types/node": 16.0.0
     "@types/supertest": 2.0.11
@@ -633,7 +854,7 @@ __metadata:
     eslint: 8.0.1
     express: 4.17.1
     handlebars: 4.7.7
-    jest: 26.6.0
+    jest: 27.4.7
     js-yaml: 4.1.0
     nanoid: 3.1.30
     nest-winston: 1.6.2
@@ -644,7 +865,7 @@ __metadata:
     source-map-support: 0.5.20
     supertest: 6.1.3
     swagger-ui-express: 4.2.0
-    ts-jest: 26.4.2
+    ts-jest: 27.1.2
     ts-loader: 9.2.3
     ts-node: 10.0.0
     tsconfig-paths: 3.10.1
@@ -989,6 +1210,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/console@npm:^27.4.6":
+  version: 27.4.6
+  resolution: "@jest/console@npm:27.4.6"
+  dependencies:
+    "@jest/types": ^27.4.2
+    "@types/node": "*"
+    chalk: ^4.0.0
+    jest-message-util: ^27.4.6
+    jest-util: ^27.4.2
+    slash: ^3.0.0
+  checksum: 603408498d2fd7fa6cfb85cc18a5823747c824be2f88be526ed4db83df65db7a9d3a93056eeaddd32ea1517d581b94862e532ccde081e0ecf9d82ac743ec6ac2
+  languageName: node
+  linkType: hard
+
 "@jest/core@npm:^26.6.0, @jest/core@npm:^26.6.3":
   version: 26.6.3
   resolution: "@jest/core@npm:26.6.3"
@@ -1066,6 +1301,47 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/core@npm:^27.4.7":
+  version: 27.4.7
+  resolution: "@jest/core@npm:27.4.7"
+  dependencies:
+    "@jest/console": ^27.4.6
+    "@jest/reporters": ^27.4.6
+    "@jest/test-result": ^27.4.6
+    "@jest/transform": ^27.4.6
+    "@jest/types": ^27.4.2
+    "@types/node": "*"
+    ansi-escapes: ^4.2.1
+    chalk: ^4.0.0
+    emittery: ^0.8.1
+    exit: ^0.1.2
+    graceful-fs: ^4.2.4
+    jest-changed-files: ^27.4.2
+    jest-config: ^27.4.7
+    jest-haste-map: ^27.4.6
+    jest-message-util: ^27.4.6
+    jest-regex-util: ^27.4.0
+    jest-resolve: ^27.4.6
+    jest-resolve-dependencies: ^27.4.6
+    jest-runner: ^27.4.6
+    jest-runtime: ^27.4.6
+    jest-snapshot: ^27.4.6
+    jest-util: ^27.4.2
+    jest-validate: ^27.4.6
+    jest-watcher: ^27.4.6
+    micromatch: ^4.0.4
+    rimraf: ^3.0.0
+    slash: ^3.0.0
+    strip-ansi: ^6.0.0
+  peerDependencies:
+    node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+  peerDependenciesMeta:
+    node-notifier:
+      optional: true
+  checksum: 24ed123ef1819fa8c6069706760efac9904ee8824b22c346259be2017d820b5e578a4d444339448a576a0158e6fec91d18fdedb201bc97d7390b105d665f3642
+  languageName: node
+  linkType: hard
+
 "@jest/create-cache-key-function@npm:^26.5.0":
   version: 26.6.2
   resolution: "@jest/create-cache-key-function@npm:26.6.2"
@@ -1099,6 +1375,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/environment@npm:^27.4.6":
+  version: 27.4.6
+  resolution: "@jest/environment@npm:27.4.6"
+  dependencies:
+    "@jest/fake-timers": ^27.4.6
+    "@jest/types": ^27.4.2
+    "@types/node": "*"
+    jest-mock: ^27.4.6
+  checksum: c3aadcf6d42e55e35d8020f7cf5054c445775608e466fcfc37348359e54f2f79e0e39d029281836ae9082dc50eac81d1cf6b4fc3899adfb58afc68a7c72f8e3d
+  languageName: node
+  linkType: hard
+
 "@jest/fake-timers@npm:^26.6.2":
   version: 26.6.2
   resolution: "@jest/fake-timers@npm:26.6.2"
@@ -1127,6 +1415,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/fake-timers@npm:^27.4.6":
+  version: 27.4.6
+  resolution: "@jest/fake-timers@npm:27.4.6"
+  dependencies:
+    "@jest/types": ^27.4.2
+    "@sinonjs/fake-timers": ^8.0.1
+    "@types/node": "*"
+    jest-message-util: ^27.4.6
+    jest-mock: ^27.4.6
+    jest-util: ^27.4.2
+  checksum: 389f655d39f13fdd0448b554260cd41810cf824b99e9de057600869a708d34cfa74e7fdaba5fcd6e3295e7bfed08f1b3fc0735ca86f7c0b2281b25e534032876
+  languageName: node
+  linkType: hard
+
 "@jest/globals@npm:^26.6.2":
   version: 26.6.2
   resolution: "@jest/globals@npm:26.6.2"
@@ -1146,6 +1448,17 @@ __metadata:
     "@jest/types": ^27.4.2
     expect: ^27.4.2
   checksum: b43d8290fbd09148961877cc859c4e23e4c7cb44c161d540fd7ab8f9dc490cf787dc346c308d7df9d23429461754156b78b36bc14b78823f51c3869106e2e0c6
+  languageName: node
+  linkType: hard
+
+"@jest/globals@npm:^27.4.6":
+  version: 27.4.6
+  resolution: "@jest/globals@npm:27.4.6"
+  dependencies:
+    "@jest/environment": ^27.4.6
+    "@jest/types": ^27.4.2
+    expect: ^27.4.6
+  checksum: a438645771f45557b3af6e371e65c88e109d7433d3d4ee5db908177f29be6d6d12b4cfe9279ae6475bc033b5ff2a97235659a75f2718855041dd3ed805ed2edd
   languageName: node
   linkType: hard
 
@@ -1223,6 +1536,44 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/reporters@npm:^27.4.6":
+  version: 27.4.6
+  resolution: "@jest/reporters@npm:27.4.6"
+  dependencies:
+    "@bcoe/v8-coverage": ^0.2.3
+    "@jest/console": ^27.4.6
+    "@jest/test-result": ^27.4.6
+    "@jest/transform": ^27.4.6
+    "@jest/types": ^27.4.2
+    "@types/node": "*"
+    chalk: ^4.0.0
+    collect-v8-coverage: ^1.0.0
+    exit: ^0.1.2
+    glob: ^7.1.2
+    graceful-fs: ^4.2.4
+    istanbul-lib-coverage: ^3.0.0
+    istanbul-lib-instrument: ^5.1.0
+    istanbul-lib-report: ^3.0.0
+    istanbul-lib-source-maps: ^4.0.0
+    istanbul-reports: ^3.1.3
+    jest-haste-map: ^27.4.6
+    jest-resolve: ^27.4.6
+    jest-util: ^27.4.2
+    jest-worker: ^27.4.6
+    slash: ^3.0.0
+    source-map: ^0.6.0
+    string-length: ^4.0.1
+    terminal-link: ^2.0.0
+    v8-to-istanbul: ^8.1.0
+  peerDependencies:
+    node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+  peerDependenciesMeta:
+    node-notifier:
+      optional: true
+  checksum: 4c14b2cf6c9b624977f9ad519e9ce2f5ead4a3c9a3fa0b9c68097b7bc78b598ceb5402566417d81e16489dbd6bb6e97e58f04c22099013897dd6010c0549b169
+  languageName: node
+  linkType: hard
+
 "@jest/source-map@npm:^26.6.2":
   version: 26.6.2
   resolution: "@jest/source-map@npm:26.6.2"
@@ -1269,6 +1620,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/test-result@npm:^27.4.6":
+  version: 27.4.6
+  resolution: "@jest/test-result@npm:27.4.6"
+  dependencies:
+    "@jest/console": ^27.4.6
+    "@jest/types": ^27.4.2
+    "@types/istanbul-lib-coverage": ^2.0.0
+    collect-v8-coverage: ^1.0.0
+  checksum: ddfc5783f2025ba979df395ddead7f76aac91df9a8a4ab15d5b1210a58e523932bb9ea9e1e97229c09cab81fdb2611292fdc8e56e2c5b44ed452ac11db7f79f0
+  languageName: node
+  linkType: hard
+
 "@jest/test-sequencer@npm:^26.6.3":
   version: 26.6.3
   resolution: "@jest/test-sequencer@npm:26.6.3"
@@ -1291,6 +1654,18 @@ __metadata:
     jest-haste-map: ^27.4.4
     jest-runtime: ^27.4.4
   checksum: 37e3df089fe15e7f7c2070c915267d89aae1dfe72f97ea210ee974f48a2797637276c46fa5481a09614c8107529578aea9e498f54e2b3ed3aa9f888d0f9e3460
+  languageName: node
+  linkType: hard
+
+"@jest/test-sequencer@npm:^27.4.6":
+  version: 27.4.6
+  resolution: "@jest/test-sequencer@npm:27.4.6"
+  dependencies:
+    "@jest/test-result": ^27.4.6
+    graceful-fs: ^4.2.4
+    jest-haste-map: ^27.4.6
+    jest-runtime: ^27.4.6
+  checksum: 8d761fd81f5cf4845a09844a8a16717fc148137f364916165ce5e1ebfc5dfd89160d4b98e7e947c97f8707500050863606d0becb8c388997efcc31cafa6f5e31
   languageName: node
   linkType: hard
 
@@ -1337,6 +1712,29 @@ __metadata:
     source-map: ^0.6.1
     write-file-atomic: ^3.0.0
   checksum: 931e323b7dc390ab6205f97b69d0e35e5efeec44a55a536bc5e4d2dab4a07955e9d2f6f6bce7b54112d83e4659c81b1c680602642fcf32dce405f26f3bb1a1b3
+  languageName: node
+  linkType: hard
+
+"@jest/transform@npm:^27.4.6":
+  version: 27.4.6
+  resolution: "@jest/transform@npm:27.4.6"
+  dependencies:
+    "@babel/core": ^7.1.0
+    "@jest/types": ^27.4.2
+    babel-plugin-istanbul: ^6.1.1
+    chalk: ^4.0.0
+    convert-source-map: ^1.4.0
+    fast-json-stable-stringify: ^2.0.0
+    graceful-fs: ^4.2.4
+    jest-haste-map: ^27.4.6
+    jest-regex-util: ^27.4.0
+    jest-util: ^27.4.2
+    micromatch: ^4.0.4
+    pirates: ^4.0.4
+    slash: ^3.0.0
+    source-map: ^0.6.1
+    write-file-atomic: ^3.0.0
+  checksum: b2500fc5a7e7cad34547acdb8930797f021cda6b811ed0626564999bfd9ca856f52cc3a9b2ced5d037f3bd06a49b8b30cb7c10259318dc67bd11a564854d2ca6
   languageName: node
   linkType: hard
 
@@ -3503,7 +3901,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-plugin-istanbul@npm:^6.0.0":
+"babel-jest@npm:^27.4.6":
+  version: 27.4.6
+  resolution: "babel-jest@npm:27.4.6"
+  dependencies:
+    "@jest/transform": ^27.4.6
+    "@jest/types": ^27.4.2
+    "@types/babel__core": ^7.1.14
+    babel-plugin-istanbul: ^6.1.1
+    babel-preset-jest: ^27.4.0
+    chalk: ^4.0.0
+    graceful-fs: ^4.2.4
+    slash: ^3.0.0
+  peerDependencies:
+    "@babel/core": ^7.8.0
+  checksum: fc839d5e8788170e68c8cbde9466fdf1c4fc740a947ba0728e1933ade7ad6fe744c9276d86207f093b64e9cf72a1fdd756fbc44c21034282f01832338e7a8a80
+  languageName: node
+  linkType: hard
+
+"babel-plugin-istanbul@npm:^6.0.0, babel-plugin-istanbul@npm:^6.1.1":
   version: 6.1.1
   resolution: "babel-plugin-istanbul@npm:6.1.1"
   dependencies:
@@ -6232,6 +6648,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"expect@npm:^27.4.6":
+  version: 27.4.6
+  resolution: "expect@npm:27.4.6"
+  dependencies:
+    "@jest/types": ^27.4.2
+    jest-get-type: ^27.4.0
+    jest-matcher-utils: ^27.4.6
+    jest-message-util: ^27.4.6
+  checksum: 593eaa8ff34320f9a70f961bc25eeae932df4f48ebcc5ecc1033f1cddffd286fc42a2f312929222541cec1077de2604ff4fc6e97012afcbd36b333bfaba82f7f
+  languageName: node
+  linkType: hard
+
 "express@npm:4.17.1":
   version: 4.17.1
   resolution: "express@npm:4.17.1"
@@ -8020,7 +8448,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"istanbul-lib-instrument@npm:^5.0.4":
+"istanbul-lib-instrument@npm:^5.0.4, istanbul-lib-instrument@npm:^5.1.0":
   version: 5.1.0
   resolution: "istanbul-lib-instrument@npm:5.1.0"
   dependencies:
@@ -8062,6 +8490,16 @@ __metadata:
     html-escaper: ^2.0.0
     istanbul-lib-report: ^3.0.0
   checksum: a9940767ee960fd21d4c9b24c417c15d38725be2f3517a72070e962e088fdf7b813f50985f660cd48436690237fdc5640bab10a1a91e0e94b0e400c212c85f3c
+  languageName: node
+  linkType: hard
+
+"istanbul-reports@npm:^3.1.3":
+  version: 3.1.3
+  resolution: "istanbul-reports@npm:3.1.3"
+  dependencies:
+    html-escaper: ^2.0.0
+    istanbul-lib-report: ^3.0.0
+  checksum: ef6e0d9ed05ecab1974c6eb46cc2a12d8570911934192db4ed40cf1978449240ea80aae32c4dd5555b67407cdf860212d1a9e415443af69641aa57ed1da5ebbb
   languageName: node
   linkType: hard
 
@@ -8132,6 +8570,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-circus@npm:^27.4.6":
+  version: 27.4.6
+  resolution: "jest-circus@npm:27.4.6"
+  dependencies:
+    "@jest/environment": ^27.4.6
+    "@jest/test-result": ^27.4.6
+    "@jest/types": ^27.4.2
+    "@types/node": "*"
+    chalk: ^4.0.0
+    co: ^4.6.0
+    dedent: ^0.7.0
+    expect: ^27.4.6
+    is-generator-fn: ^2.0.0
+    jest-each: ^27.4.6
+    jest-matcher-utils: ^27.4.6
+    jest-message-util: ^27.4.6
+    jest-runtime: ^27.4.6
+    jest-snapshot: ^27.4.6
+    jest-util: ^27.4.2
+    pretty-format: ^27.4.6
+    slash: ^3.0.0
+    stack-utils: ^2.0.3
+    throat: ^6.0.1
+  checksum: 00aae02bc4de4afa2144b073c4158a322cb37924d5583ef5caa5cb4badcc8f32474da3a01dd5672e85eda088b92d2b769986b46e36c2c88df0dd6ec0c72bd8c1
+  languageName: node
+  linkType: hard
+
 "jest-cli@npm:^26.6.0":
   version: 26.6.3
   resolution: "jest-cli@npm:26.6.3"
@@ -8179,6 +8644,33 @@ __metadata:
   bin:
     jest: bin/jest.js
   checksum: bb19871a076fa23d1a3e198b7537f7a817b57ed8664202ec02a5f6cfab7c2d9cb7a84ba000406e931c29ffea2374d91d88b96f8b1bbf4fefdd51f31ee688f6f3
+  languageName: node
+  linkType: hard
+
+"jest-cli@npm:^27.4.7":
+  version: 27.4.7
+  resolution: "jest-cli@npm:27.4.7"
+  dependencies:
+    "@jest/core": ^27.4.7
+    "@jest/test-result": ^27.4.6
+    "@jest/types": ^27.4.2
+    chalk: ^4.0.0
+    exit: ^0.1.2
+    graceful-fs: ^4.2.4
+    import-local: ^3.0.2
+    jest-config: ^27.4.7
+    jest-util: ^27.4.2
+    jest-validate: ^27.4.6
+    prompts: ^2.0.1
+    yargs: ^16.2.0
+  peerDependencies:
+    node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+  peerDependenciesMeta:
+    node-notifier:
+      optional: true
+  bin:
+    jest: bin/jest.js
+  checksum: bf301039f1c14ef3fa2b7699b7b94328faa5549e34cb1573610c894bedd036ad36e31e6af436e11b3aa85e22e409a05d1fef1624bebc2da7ed416ce969b87307
   languageName: node
   linkType: hard
 
@@ -8248,6 +8740,41 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-config@npm:^27.4.7":
+  version: 27.4.7
+  resolution: "jest-config@npm:27.4.7"
+  dependencies:
+    "@babel/core": ^7.8.0
+    "@jest/test-sequencer": ^27.4.6
+    "@jest/types": ^27.4.2
+    babel-jest: ^27.4.6
+    chalk: ^4.0.0
+    ci-info: ^3.2.0
+    deepmerge: ^4.2.2
+    glob: ^7.1.1
+    graceful-fs: ^4.2.4
+    jest-circus: ^27.4.6
+    jest-environment-jsdom: ^27.4.6
+    jest-environment-node: ^27.4.6
+    jest-get-type: ^27.4.0
+    jest-jasmine2: ^27.4.6
+    jest-regex-util: ^27.4.0
+    jest-resolve: ^27.4.6
+    jest-runner: ^27.4.6
+    jest-util: ^27.4.2
+    jest-validate: ^27.4.6
+    micromatch: ^4.0.4
+    pretty-format: ^27.4.6
+    slash: ^3.0.0
+  peerDependencies:
+    ts-node: ">=9.0.0"
+  peerDependenciesMeta:
+    ts-node:
+      optional: true
+  checksum: 23d5bacc483b2674d6efcd6bfc66bcde7c2b428511b50d17a22a2750d85bfc23753f9e41f504411e411e848e34ec61244bdae9da8782df4ada6e284106f71a4d
+  languageName: node
+  linkType: hard
+
 "jest-diff@npm:^25.2.1":
   version: 25.5.0
   resolution: "jest-diff@npm:25.5.0"
@@ -8281,6 +8808,18 @@ __metadata:
     jest-get-type: ^27.4.0
     pretty-format: ^27.4.2
   checksum: e5bcdb4f27747795b74a56d56a9545d7fc8f1671a1251d580aea1a7a52df5db044f62ec24f2abc68305f0226d918a443f3b88d9a82f8d0dc4aaa079b621ab091
+  languageName: node
+  linkType: hard
+
+"jest-diff@npm:^27.4.6":
+  version: 27.4.6
+  resolution: "jest-diff@npm:27.4.6"
+  dependencies:
+    chalk: ^4.0.0
+    diff-sequences: ^27.4.0
+    jest-get-type: ^27.4.0
+    pretty-format: ^27.4.6
+  checksum: cf6b7e80e3c64a7c71ab209c0325bbda175991aed985ecee7652df9d6540e4959089038e208c04ab05391c9ddf07adc72f0c8c26cc4cee6fa17f76f500e2bf43
   languageName: node
   linkType: hard
 
@@ -8328,6 +8867,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-each@npm:^27.4.6":
+  version: 27.4.6
+  resolution: "jest-each@npm:27.4.6"
+  dependencies:
+    "@jest/types": ^27.4.2
+    chalk: ^4.0.0
+    jest-get-type: ^27.4.0
+    jest-util: ^27.4.2
+    pretty-format: ^27.4.6
+  checksum: cce85a14a4c3a37733e75da2352e767c6eef923181e0c884eb9f86253ed417de0454da5117ebfbc1fcabdf109a305b1dbbf9b71a5712da8b6d79fde1f73a9b75
+  languageName: node
+  linkType: hard
+
 "jest-environment-jsdom@npm:^26.6.2":
   version: 26.6.2
   resolution: "jest-environment-jsdom@npm:26.6.2"
@@ -8358,6 +8910,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-environment-jsdom@npm:^27.4.6":
+  version: 27.4.6
+  resolution: "jest-environment-jsdom@npm:27.4.6"
+  dependencies:
+    "@jest/environment": ^27.4.6
+    "@jest/fake-timers": ^27.4.6
+    "@jest/types": ^27.4.2
+    "@types/node": "*"
+    jest-mock: ^27.4.6
+    jest-util: ^27.4.2
+    jsdom: ^16.6.0
+  checksum: bdf5f349a3e96b029fd0c442c8ba86dd7beb8d14922b6a53f0c52f9ab7b34521ef8deedfaba13ce81ca01e9074032eb8dc506d9035941348e129d0b76671d6bc
+  languageName: node
+  linkType: hard
+
 "jest-environment-node@npm:^26.6.2":
   version: 26.6.2
   resolution: "jest-environment-node@npm:26.6.2"
@@ -8383,6 +8950,20 @@ __metadata:
     jest-mock: ^27.4.2
     jest-util: ^27.4.2
   checksum: 12de67100d35dcdab012220d5c9663e3ad6ac0b164b0a89e998a30c41b71c96abd77256f4fbfcd0ec48f8acb1dbb084050a5d17fe0ad4b4a81e311e05b54a89d
+  languageName: node
+  linkType: hard
+
+"jest-environment-node@npm:^27.4.6":
+  version: 27.4.6
+  resolution: "jest-environment-node@npm:27.4.6"
+  dependencies:
+    "@jest/environment": ^27.4.6
+    "@jest/fake-timers": ^27.4.6
+    "@jest/types": ^27.4.2
+    "@types/node": "*"
+    jest-mock: ^27.4.6
+    jest-util: ^27.4.2
+  checksum: 3f146e7819f65b1dc0252573cddadc8c565a566ddf7c06c93eded51cccfc55f4765373fb2aaafeb4d8b76ec62b062e1bd4f1da6b9f57429af6789ef8bbada3cb
   languageName: node
   linkType: hard
 
@@ -8456,6 +9037,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-haste-map@npm:^27.4.6":
+  version: 27.4.6
+  resolution: "jest-haste-map@npm:27.4.6"
+  dependencies:
+    "@jest/types": ^27.4.2
+    "@types/graceful-fs": ^4.1.2
+    "@types/node": "*"
+    anymatch: ^3.0.3
+    fb-watchman: ^2.0.0
+    fsevents: ^2.3.2
+    graceful-fs: ^4.2.4
+    jest-regex-util: ^27.4.0
+    jest-serializer: ^27.4.0
+    jest-util: ^27.4.2
+    jest-worker: ^27.4.6
+    micromatch: ^4.0.4
+    walker: ^1.0.7
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  checksum: 07a336e9dba9e7308f16c8b8e037dcc80eb346b0f68cbb6bd1badf97abb104da12c305b411549a5ac0bd4e634b61f9d12e0b5ac2ae8e8bea08952a5fe1a6e82e
+  languageName: node
+  linkType: hard
+
 "jest-jasmine2@npm:^26.6.3":
   version: 26.6.3
   resolution: "jest-jasmine2@npm:26.6.3"
@@ -8508,6 +9113,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-jasmine2@npm:^27.4.6":
+  version: 27.4.6
+  resolution: "jest-jasmine2@npm:27.4.6"
+  dependencies:
+    "@jest/environment": ^27.4.6
+    "@jest/source-map": ^27.4.0
+    "@jest/test-result": ^27.4.6
+    "@jest/types": ^27.4.2
+    "@types/node": "*"
+    chalk: ^4.0.0
+    co: ^4.6.0
+    expect: ^27.4.6
+    is-generator-fn: ^2.0.0
+    jest-each: ^27.4.6
+    jest-matcher-utils: ^27.4.6
+    jest-message-util: ^27.4.6
+    jest-runtime: ^27.4.6
+    jest-snapshot: ^27.4.6
+    jest-util: ^27.4.2
+    pretty-format: ^27.4.6
+    throat: ^6.0.1
+  checksum: d9b05405708161b90c2e9add00ee3c62b154b0f839bc50f034ae8369921956bb16cec428e46ae3b8074a3aeded6cb02f770161d7453f1a183b1abac17dae43f7
+  languageName: node
+  linkType: hard
+
 "jest-leak-detector@npm:^26.6.2":
   version: 26.6.2
   resolution: "jest-leak-detector@npm:26.6.2"
@@ -8525,6 +9155,16 @@ __metadata:
     jest-get-type: ^27.4.0
     pretty-format: ^27.4.2
   checksum: 093ef57aa6f5563ed5e2c0bce31f8d2ac65438c5d917457dd9a392bf11956a976b55ef2b536cf593b1d65283430305cb6d26e97b064a5c140146346103e74184
+  languageName: node
+  linkType: hard
+
+"jest-leak-detector@npm:^27.4.6":
+  version: 27.4.6
+  resolution: "jest-leak-detector@npm:27.4.6"
+  dependencies:
+    jest-get-type: ^27.4.0
+    pretty-format: ^27.4.6
+  checksum: 4259400403d51b1297b9ab05c1342345c4a93a77c99447b061192ed81b56efcbdd28a03914c9f97670d2f3498bdc368712575d6218b02e3af1656b7db507d3bf
   languageName: node
   linkType: hard
 
@@ -8549,6 +9189,18 @@ __metadata:
     jest-get-type: ^27.4.0
     pretty-format: ^27.4.2
   checksum: 7dd9d2f1f7107d5919af170f9d3e2a08890ce05ee63f6fc3a24e6c8fa9672f99ed107377ae7c6d4d0966a77fa35a3da929465b019b6f1be8cf7e0845806bceb3
+  languageName: node
+  linkType: hard
+
+"jest-matcher-utils@npm:^27.4.6":
+  version: 27.4.6
+  resolution: "jest-matcher-utils@npm:27.4.6"
+  dependencies:
+    chalk: ^4.0.0
+    jest-diff: ^27.4.6
+    jest-get-type: ^27.4.0
+    pretty-format: ^27.4.6
+  checksum: 445a8cc9eaa7cb08653a10cfc4f109eca76a97d1b1d3a01067bd77efa9cb3a554b74c7402a4c9d5083b21e11218e1515ef538faa47fa47c282072b4825f6b307
   languageName: node
   linkType: hard
 
@@ -8586,6 +9238,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-message-util@npm:^27.4.6":
+  version: 27.4.6
+  resolution: "jest-message-util@npm:27.4.6"
+  dependencies:
+    "@babel/code-frame": ^7.12.13
+    "@jest/types": ^27.4.2
+    "@types/stack-utils": ^2.0.0
+    chalk: ^4.0.0
+    graceful-fs: ^4.2.4
+    micromatch: ^4.0.4
+    pretty-format: ^27.4.6
+    slash: ^3.0.0
+    stack-utils: ^2.0.3
+  checksum: 1fdd542d091dbf7aa63a484feead97a921e3c4d6db3784fe2e6d83e9110ac06de5691fdc043da991ca1d0ce5d179ea8266c8d93b388f4bba7d80a267fdd946df
+  languageName: node
+  linkType: hard
+
 "jest-mock@npm:^26.6.2":
   version: 26.6.2
   resolution: "jest-mock@npm:26.6.2"
@@ -8603,6 +9272,16 @@ __metadata:
     "@jest/types": ^27.4.2
     "@types/node": "*"
   checksum: 4ad4a870ec771410b708e955ef2526e7becb91a1d19c4699dcf8fe43a9f6d1231e0c47b87d6b80ee9ad3194ad54dc9abf158588a4a542ad9f9ce8c23eda6048e
+  languageName: node
+  linkType: hard
+
+"jest-mock@npm:^27.4.6":
+  version: 27.4.6
+  resolution: "jest-mock@npm:27.4.6"
+  dependencies:
+    "@jest/types": ^27.4.2
+    "@types/node": "*"
+  checksum: 34df5ec502fa0db5ef36e2b2e96a522de730e7be907c6df5d4ec8ab1292d9be71f1e269e8bcdafd020239edaf3ca6f9c464eb0b4aca6986420a1f392976fc0ab
   languageName: node
   linkType: hard
 
@@ -8654,6 +9333,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-resolve-dependencies@npm:^27.4.6":
+  version: 27.4.6
+  resolution: "jest-resolve-dependencies@npm:27.4.6"
+  dependencies:
+    "@jest/types": ^27.4.2
+    jest-regex-util: ^27.4.0
+    jest-snapshot: ^27.4.6
+  checksum: c644adb74a602c8c08f90256c9a5c519434cd213a02a6f427425003f9ab026c12860527eb67cf624aa6717c410fa92aee66662d212c0ffbb73f80e2711ffb7a4
+  languageName: node
+  linkType: hard
+
 "jest-resolve@npm:^26.6.2":
   version: 26.6.2
   resolution: "jest-resolve@npm:26.6.2"
@@ -8685,6 +9375,24 @@ __metadata:
     resolve.exports: ^1.1.0
     slash: ^3.0.0
   checksum: 2dd3b27cc018adb754ac059c0f90eae5d8a92b3b2e0a24f16a22c448456c2f025cebd324f2408a7db229f251da76526592bde81c5cf4a408f1403571a592b7b0
+  languageName: node
+  linkType: hard
+
+"jest-resolve@npm:^27.4.6":
+  version: 27.4.6
+  resolution: "jest-resolve@npm:27.4.6"
+  dependencies:
+    "@jest/types": ^27.4.2
+    chalk: ^4.0.0
+    graceful-fs: ^4.2.4
+    jest-haste-map: ^27.4.6
+    jest-pnp-resolver: ^1.2.2
+    jest-util: ^27.4.2
+    jest-validate: ^27.4.6
+    resolve: ^1.20.0
+    resolve.exports: ^1.1.0
+    slash: ^3.0.0
+  checksum: 69b765660ee2dd71542953fbe5f6fc9ee3590a4829376e00d955f7566d47049ec5e300832bee1530ac85d2946e341558993ab381d3023363058ae6f9d4c10025
   languageName: node
   linkType: hard
 
@@ -8743,6 +9451,36 @@ __metadata:
     source-map-support: ^0.5.6
     throat: ^6.0.1
   checksum: fe9764e43e02e79d600446cca01664cc4c9957993c7c4ee8795af251f765b378f0da8748fae190cce0916eedd408b9601c452df666c18aece1ac70c5d6fd4019
+  languageName: node
+  linkType: hard
+
+"jest-runner@npm:^27.4.6":
+  version: 27.4.6
+  resolution: "jest-runner@npm:27.4.6"
+  dependencies:
+    "@jest/console": ^27.4.6
+    "@jest/environment": ^27.4.6
+    "@jest/test-result": ^27.4.6
+    "@jest/transform": ^27.4.6
+    "@jest/types": ^27.4.2
+    "@types/node": "*"
+    chalk: ^4.0.0
+    emittery: ^0.8.1
+    exit: ^0.1.2
+    graceful-fs: ^4.2.4
+    jest-docblock: ^27.4.0
+    jest-environment-jsdom: ^27.4.6
+    jest-environment-node: ^27.4.6
+    jest-haste-map: ^27.4.6
+    jest-leak-detector: ^27.4.6
+    jest-message-util: ^27.4.6
+    jest-resolve: ^27.4.6
+    jest-runtime: ^27.4.6
+    jest-util: ^27.4.2
+    jest-worker: ^27.4.6
+    source-map-support: ^0.5.6
+    throat: ^6.0.1
+  checksum: 4e76117e5373b6eb51c7113f848dbc92bc1e1d2f1302f9530ef9cb6c967eb364836f4a5790f65a437f47debc917bfb696bbc647831292fa8b1b4321f292e721f
   languageName: node
   linkType: hard
 
@@ -8814,6 +9552,36 @@ __metadata:
     strip-bom: ^4.0.0
     yargs: ^16.2.0
   checksum: f12cfcd7db91d1f36613a884493e68f255fff529504c25e77af0c60fea71fa526ebe401f27aaf05b8e563e365339829f6c39b2196159be4da6ea3445408d5d7b
+  languageName: node
+  linkType: hard
+
+"jest-runtime@npm:^27.4.6":
+  version: 27.4.6
+  resolution: "jest-runtime@npm:27.4.6"
+  dependencies:
+    "@jest/environment": ^27.4.6
+    "@jest/fake-timers": ^27.4.6
+    "@jest/globals": ^27.4.6
+    "@jest/source-map": ^27.4.0
+    "@jest/test-result": ^27.4.6
+    "@jest/transform": ^27.4.6
+    "@jest/types": ^27.4.2
+    chalk: ^4.0.0
+    cjs-module-lexer: ^1.0.0
+    collect-v8-coverage: ^1.0.0
+    execa: ^5.0.0
+    glob: ^7.1.3
+    graceful-fs: ^4.2.4
+    jest-haste-map: ^27.4.6
+    jest-message-util: ^27.4.6
+    jest-mock: ^27.4.6
+    jest-regex-util: ^27.4.0
+    jest-resolve: ^27.4.6
+    jest-snapshot: ^27.4.6
+    jest-util: ^27.4.2
+    slash: ^3.0.0
+    strip-bom: ^4.0.0
+  checksum: 64d833c7d7b1d67b53932dc9fd9332aaf43ea1777fc61c3f143515968f066438b3247e4f1a71a7f127b1bedbc7c3124bfc53cb4f026fff5b26e2feda8d35535c
   languageName: node
   linkType: hard
 
@@ -8893,6 +9661,36 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-snapshot@npm:^27.4.6":
+  version: 27.4.6
+  resolution: "jest-snapshot@npm:27.4.6"
+  dependencies:
+    "@babel/core": ^7.7.2
+    "@babel/generator": ^7.7.2
+    "@babel/plugin-syntax-typescript": ^7.7.2
+    "@babel/traverse": ^7.7.2
+    "@babel/types": ^7.0.0
+    "@jest/transform": ^27.4.6
+    "@jest/types": ^27.4.2
+    "@types/babel__traverse": ^7.0.4
+    "@types/prettier": ^2.1.5
+    babel-preset-current-node-syntax: ^1.0.0
+    chalk: ^4.0.0
+    expect: ^27.4.6
+    graceful-fs: ^4.2.4
+    jest-diff: ^27.4.6
+    jest-get-type: ^27.4.0
+    jest-haste-map: ^27.4.6
+    jest-matcher-utils: ^27.4.6
+    jest-message-util: ^27.4.6
+    jest-util: ^27.4.2
+    natural-compare: ^1.4.0
+    pretty-format: ^27.4.6
+    semver: ^7.3.2
+  checksum: c7a1ae993ae7334277c61e6d645efedefce53ca212498ae766ea28efa46287559a56d2bd2edaaead8476191a45adbb1354df5367dfd223763b5a66751bfbda14
+  languageName: node
+  linkType: hard
+
 "jest-util@npm:^26.1.0, jest-util@npm:^26.6.2":
   version: 26.6.2
   resolution: "jest-util@npm:26.6.2"
@@ -8907,7 +9705,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-util@npm:^27.4.2":
+"jest-util@npm:^27.0.0, jest-util@npm:^27.4.2":
   version: 27.4.2
   resolution: "jest-util@npm:27.4.2"
   dependencies:
@@ -8949,6 +9747,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-validate@npm:^27.4.6":
+  version: 27.4.6
+  resolution: "jest-validate@npm:27.4.6"
+  dependencies:
+    "@jest/types": ^27.4.2
+    camelcase: ^6.2.0
+    chalk: ^4.0.0
+    jest-get-type: ^27.4.0
+    leven: ^3.1.0
+    pretty-format: ^27.4.6
+  checksum: d3578030eadd872b99e65dac24d9ca755f2a2483f8344d9e575ea6034c6cb5ed5bcf7a4aa4f1050ab0080d5a8d0b0efd31c911514f27820b871a636a97dc196c
+  languageName: node
+  linkType: hard
+
 "jest-watcher@npm:^26.6.2":
   version: 26.6.2
   resolution: "jest-watcher@npm:26.6.2"
@@ -8976,6 +9788,21 @@ __metadata:
     jest-util: ^27.4.2
     string-length: ^4.0.1
   checksum: f6078349e5c4638b8778dfad0e846aba5665f3bf1f8e8565c436533a5effd8592123b99f950d534965d841edef391ecd86849f5d4ea7d737f99daa7ecfd643cb
+  languageName: node
+  linkType: hard
+
+"jest-watcher@npm:^27.4.6":
+  version: 27.4.6
+  resolution: "jest-watcher@npm:27.4.6"
+  dependencies:
+    "@jest/test-result": ^27.4.6
+    "@jest/types": ^27.4.2
+    "@types/node": "*"
+    ansi-escapes: ^4.2.1
+    chalk: ^4.0.0
+    jest-util: ^27.4.2
+    string-length: ^4.0.1
+  checksum: bb9c0a34dcc690cef6430c275e81213620bc4ba6337e42302efa51666ac06781e9f6f50c930332396e4e8cd8cc47de8fb2e8de57da0f7e35a246b0206dde1cd3
   languageName: node
   linkType: hard
 
@@ -9012,6 +9839,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-worker@npm:^27.4.6":
+  version: 27.4.6
+  resolution: "jest-worker@npm:27.4.6"
+  dependencies:
+    "@types/node": "*"
+    merge-stream: ^2.0.0
+    supports-color: ^8.0.0
+  checksum: 105bcdf5c66700bbfe352bc09476629ca0858cfa819fcc1a37ea76660f0168d586c6e77aee8ea91eded5a20f40f331a0a81e503b5ba19f7b566204406b239466
+  languageName: node
+  linkType: hard
+
 "jest@npm:26.6.0":
   version: 26.6.0
   resolution: "jest@npm:26.6.0"
@@ -9040,6 +9878,24 @@ __metadata:
   bin:
     jest: bin/jest.js
   checksum: 726dbdaaad94eccae084a5bdd85cbe9c308b4a3d331f2315f1cad6447858cc5b1aaa730d6b63dcf29b4f8258a8271086bdc812a4dd04113085c48975782f8bfa
+  languageName: node
+  linkType: hard
+
+"jest@npm:27.4.7":
+  version: 27.4.7
+  resolution: "jest@npm:27.4.7"
+  dependencies:
+    "@jest/core": ^27.4.7
+    import-local: ^3.0.2
+    jest-cli: ^27.4.7
+  peerDependencies:
+    node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+  peerDependenciesMeta:
+    node-notifier:
+      optional: true
+  bin:
+    jest: bin/jest.js
+  checksum: 28ce948b30c074907393f37553acac4422d0f60190776e62b3403e4c742d33dd6012e3a20748254a43e38b5b4ce52d813b13a3a5be1d43d6d12429bd08ce1a23
   languageName: node
   linkType: hard
 
@@ -11124,7 +11980,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pirates@npm:^4.0.1":
+"pirates@npm:^4.0.1, pirates@npm:^4.0.4":
   version: 4.0.4
   resolution: "pirates@npm:4.0.4"
   checksum: 6b7187d526fd025a2b91e8fd289c78d88c4adc3ea947b9facbe9cb300a896b0ec00f3e77b36a043001695312a8debbf714453495283bd8a4eaad3bc0c38df425
@@ -11357,6 +12213,17 @@ __metadata:
     ansi-styles: ^5.0.0
     react-is: ^17.0.1
   checksum: 0daaf00c4dcb35493e57d30147e8045d0c45cb47fc4c94e3ab1892401abe939627c39975c77cc81eb2581aaa5b12bf23ef669fa550bec68b396fb79dd8c10afa
+  languageName: node
+  linkType: hard
+
+"pretty-format@npm:^27.4.6":
+  version: 27.4.6
+  resolution: "pretty-format@npm:27.4.6"
+  dependencies:
+    ansi-regex: ^5.0.1
+    ansi-styles: ^5.0.0
+    react-is: ^17.0.1
+  checksum: 5eda32e4e47ddd1a9e8fe9ebef519b217ba403eb8bcb804ba551dfb37f87e674472013fcf78480ab535844fdddcc706fac94511eba349bfb94a138a02d1a7a59
   languageName: node
   linkType: hard
 
@@ -13598,6 +14465,40 @@ __metadata:
   bin:
     ts-jest: cli.js
   checksum: 9a2a0328324806de4a59b874235c7744837941c42d6f355a41fb3666e49a702bfdc9a872a8ac00f2e133e84e5b8f565e98d6c96750bcfe513795ef0fbe7ddf67
+  languageName: node
+  linkType: hard
+
+"ts-jest@npm:27.1.2":
+  version: 27.1.2
+  resolution: "ts-jest@npm:27.1.2"
+  dependencies:
+    bs-logger: 0.x
+    fast-json-stable-stringify: 2.x
+    jest-util: ^27.0.0
+    json5: 2.x
+    lodash.memoize: 4.x
+    make-error: 1.x
+    semver: 7.x
+    yargs-parser: 20.x
+  peerDependencies:
+    "@babel/core": ">=7.0.0-beta.0 <8"
+    "@types/jest": ^27.0.0
+    babel-jest: ">=27.0.0 <28"
+    esbuild: ~0.14.0
+    jest: ^27.0.0
+    typescript: ">=3.8 <5.0"
+  peerDependenciesMeta:
+    "@babel/core":
+      optional: true
+    "@types/jest":
+      optional: true
+    babel-jest:
+      optional: true
+    esbuild:
+      optional: true
+  bin:
+    ts-jest: cli.js
+  checksum: 2e7275f8a3545ec1340b37c458ace9244b5903e86861eb108beffff97d433f296c1254f76a41b573b1fe6245110b21bb62150bb88d55159f1dc7a929886535cb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- `make api-integration-test` to run integration tests with a transient postgres container
- Integration tests use their own DB config + env vars
- Test docker-compose for test db + make commands
- Fix up integration test setup
- Extract validationpipe config for use in integration testing
- sendMailable returns void if chesHost doesn't exist
- Add basic tests for submissions