### PR TITLE
Ignore react-select / pa11y false positive 

### DIFF
--- a/packages/accessibility/src/submission.pa11y-ci.js
+++ b/packages/accessibility/src/submission.pa11y-ci.js
@@ -22,6 +22,7 @@ const urls = [
   {
     url: 'http://localhost:3000/submission/3',
     actions: [screenCap('screencap_credential')],
+    hideElements: 'div[class*="singleValue"]',
   },
   {
     url: 'http://localhost:3000/submission/4',


### PR DESCRIPTION
We've manually verified the contrast issue is a false positive due to the complex implementation of the third party dropdown library. By adding a specific selector to the `hideElements` property in our accessibility tests we can specifically ignore this false positive