### PR TITLE
EHPR-270 - add script to send email blast using SES

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "apps/*"
   ],
   "devDependencies": {
+    "@supercharge/promise-pool": "3.0.0",
     "@tsconfig/node14": "1.0.1",
     "@typescript-eslint/eslint-plugin": "5.0.0",
     "@typescript-eslint/parser": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "apps/*"
   ],
   "devDependencies": {
-    "@supercharge/promise-pool": "3.0.0",
     "@tsconfig/node14": "1.0.1",
     "@typescript-eslint/eslint-plugin": "5.0.0",
     "@typescript-eslint/parser": "5.0.0",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -9,6 +9,7 @@
     "send-email-blast": "node src/send-email-blast.js"
   },
   "dependencies": {
+    "@supercharge/promise-pool": "3.0.0",
     "csv-parser": "3.0.0",
     "csv-writer": "1.6.0"
   }

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "transform-locations": "node src/locations.js",
     "transform-streams": "node src/streams.js",
-    "transform-submission_export": "node src/submission_export.js"
+    "transform-submission_export": "node src/submission_export.js",
+    "send-email-blast": "node src/send-email-blast.js"
   },
   "dependencies": {
     "csv-parser": "3.0.0",

--- a/packages/scripts/src/constants.js
+++ b/packages/scripts/src/constants.js
@@ -1,0 +1,72 @@
+// sample templates
+// TO-DO: confirm actual email template being sent
+export const subjectOne = 'Emergency Health Provider Registry Confirmation';
+export const templateOne = `
+<body>
+    <p>
+      You are receiving this email because you have registered on British Columbia's Emergency
+      <br />
+      Health Provider Registry (EHPR). Thank you very much for your willingness and interest in
+      <br />
+      supporting BC's health system.
+    </p>
+  
+    <p>
+      Since its launch, the program has adapted to respond to an increase in demand as a result of
+      <br />
+      climate change (e.g., wildfires, floods), as well as a global pandemic. More than 10,000 
+      <br/> 
+      people are currently registered with the EHPR and the Ministry of Health is undertaking a 
+      <br/>
+      refresh of the system to update registrant information and improve our capacity to contact
+      <br/>
+      and deploy registrants in a timely way.
+    </p>
+    
+    <p>
+      <b>
+        <i>
+        If you are still interested in being an active registrant with the EHPR and want to be 
+        <br/>
+        considered for current and future emergency deployments,
+         <a href="https://ehpr.gov.bc.ca/submission/1">
+          please click this link to register
+          <br/>
+          with the new system.
+        </a> If you do not complete the new form, you will be removed from the
+        <br/>
+        EHPR and will no longer be considered when opportunities arise.
+        </b>
+      </p>At this time, health authorities are interested in contacting registrants to support the <br/>
+       following service areas:
+    </p>
+    <ul>
+      <li>Hospital settings including: critical care, intensive care, emergency departments and support staff</li>
+      <li>Long-term care and/or Assisted living</li>
+      <li>Long-term care</li>
+      <li>Home support</li>
+      <li>COVID-19 specific support (such as immunization and testing)</li>
+    </ul>
+    <p>
+    Supports may be available to registrants willing to deploy and there may be opportunities for
+    <br/>
+    recently retired registrants (those with Temporary Emergency Registration).If you chose to
+    <br/>
+    re-affirm your registration, thank you for your continued interest in the EHRP. If you do not, 
+    <br/>
+    thank you for your initial registration. We could not do this work without the commitment and 
+    <br/>
+    support of dedicated professionals like yourself. 
+    <br/>
+    <br/>
+    If you have any questions, please email EHPRQuestions@gov.bc.ca.    
+    </p>
+    <br />
+    Sincerely,
+    <br />
+    <br />
+    Mark Armitage, Assistant Deputy
+    <br />
+    Minister Health Sector Workforce and Beneficiary Services Division
+  </body>
+`;

--- a/packages/scripts/src/send-email-blast.js
+++ b/packages/scripts/src/send-email-blast.js
@@ -128,7 +128,7 @@ async function sendEmails(max) {
     emails = emails.slice(0, max);
   }
 
-  //emails = findDuplicates(emails);
+  emails = findDuplicates(emails);
 
   if (emails.length > 0) {
     // Set up promise pool to allow 10 emails to be processed concurrently at one time

--- a/packages/scripts/src/send-email-blast.js
+++ b/packages/scripts/src/send-email-blast.js
@@ -1,0 +1,190 @@
+import fs from 'fs';
+import dotenv from 'dotenv';
+import { readFileSync } from 'fs';
+import aws from 'aws-sdk';
+import * as handlebars from 'handlebars';
+
+import { subjectOne, templateOne } from './constants.js';
+dotenv.config({ path: '../../.env' });
+
+const MAX_RETRY = 5;
+let retryCount = 0;
+let errors = [];
+let sent = 0;
+
+const credentials = new aws.Credentials({
+  accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+  secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+  sessionToken: process.env.AWS_SESSION_TOKEN,
+});
+aws.config.credentials = credentials;
+aws.config.region = process.env.AWS_S3_REGION;
+
+// authenticate aws ses
+const ses = new aws.SES();
+
+// Five requests per second
+const targetRate = 10;
+
+// genereates csv file for any email NOT sent
+function generateEmailCSV(array, outputFilePath) {
+  let fulltext = 'name,email\n';
+  array.map(row => {
+    fulltext += `${row.name},${row.email}\n`;
+  });
+  fs.writeFileSync(outputFilePath, fulltext);
+}
+
+// get emails from csv file
+async function getEmails() {
+  // await new Promise(resolve => {
+  //   setTimeout(resolve(), 1000);
+  // });
+  const file = readFileSync('./in/emails.csv').toString();
+  // Split the string into rows, discard the columns row
+  return file
+    .split('\n')
+    .slice(1)
+    .map((rowString, index) => {
+      // Split each row into it's variables
+      let row = rowString.split(',');
+      return {
+        name: row[0].trim(),
+        email: row[1].trim(),
+        confirmation_id: row[2].trim(),
+      };
+    });
+}
+
+function printProgress(progress) {
+  process.stdout.clearLine();
+  process.stdout.cursorTo(0);
+  process.stdout.write(progress);
+}
+
+// remove duplicate email entries
+function findDuplicates(emails) {
+  let unique = [];
+  let result = [];
+  emails.forEach(email => {
+    if (!unique.includes(email.email)) {
+      unique.push(email.email);
+      result.push(email);
+    } else {
+      console.log('Duplicate found', JSON.stringify(email));
+    }
+  });
+  return result;
+}
+
+// get handlebar template
+// function getTemplate() {
+//   const templatePath = path.resolve(`${__dirname}/templates/email-blast-template.hbs`);
+
+//   const templateContent = fs.readFileSync(templatePath, 'utf-8');
+//   const template = handlebars.compile(templateContent, { strict: true });
+//   const body = template(mailable.context);
+//   return body;
+// }
+
+// send individual emails using AWS SES
+async function sendEmail(user) {
+  const { name, email, confirmation_id } = user;
+  // unsure of actual template body, using hardcoded html string for now
+  const mailOptions = {
+    from: process.env.MAIL_FROM,
+    to: [email],
+    subject: subjectOne,
+    body: templateOne,
+  };
+
+  if (!ses) return;
+
+  const params = {
+    Destination: {
+      ToAddresses: [...mailOptions.to],
+    },
+    Message: {
+      Body: {
+        Html: {
+          Charset: 'UTF-8',
+          Data: mailOptions.body,
+        },
+      },
+      Subject: {
+        Charset: 'UTF-8',
+        Data: mailOptions.subject,
+      },
+    },
+    //TO-DO: testing purposes, need to remove and replace with prod
+    Source: 'EHPRDoNotReply@dev.ehpr.freshworks.club',
+    // Source: process.env.MAIL_FROM || 'EHPRDoNotReply@dev.ehpr.freshworks.club',
+  };
+
+  try {
+    console.log('Trying to Send Email');
+    const mail = await ses.sendEmail(params).promise();
+    sent++;
+    return mail;
+  } catch (e) {
+    // set max retry count for failed emails
+    if (MAX_RETRY > retryCount) {
+      console.log(`Will try sending to ${user.email} ${MAX_RETRY - retryCount} more time(s)`);
+      retryCount++;
+      await sendEmail(user);
+    } else {
+      errors.push(user);
+      console.error(e.message);
+    }
+  }
+}
+
+// function to setup and send emails
+async function sendEmails(max) {
+  let emails = await getEmails();
+  console.log(`Sending ${emails.length} emails has begun...`);
+
+  // guard to limit emails and remove ones over max limit
+  // outputs to csv file
+  if (emails.length > max) {
+    generateEmailCSV(emails.slice(max), `out/unsent_emails${Date.now()}.csv`);
+    emails = emails.slice(0, max);
+  }
+
+  emails = findDuplicates(emails);
+  let start = new Date();
+
+  // Set up interval function to run multiple sends at a set rate.
+  const interval = setInterval(() => {
+    if (emails.length) {
+      const now = new Date();
+      const duration = (now - start) / 1000;
+      const currentRate = sent / duration;
+      printProgress(
+        `Current ${currentRate.toPrecision(3)}  Errors: ${errors.length} Completed: ${sent}`,
+      );
+      // Only send email if we are under the targeted rate
+      if (currentRate <= targetRate) {
+        new Promise(async resolve => {
+          const current = emails.pop();
+          await sendEmail(current);
+          resolve();
+        });
+      }
+    } else {
+      // When the email queue is empty, clear the interval and store failed sends in a csv
+      clearInterval(interval);
+      console.log(`\x1b[32mCompleted Count\x1b[0m: ${sent}`);
+      console.log(`\x1b[31mFailed Count\x1b[0m: ${errors.length}`);
+      if (errors.length > 0) {
+        generateEmailCSV(errors, './out/errors.csv');
+      }
+    }
+  }, 10);
+}
+
+async function main() {
+  await sendEmails(9000);
+}
+
+main();

--- a/yarn.lock
+++ b/yarn.lock
@@ -917,6 +917,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@ehpr/scripts@workspace:packages/scripts"
   dependencies:
+    "@supercharge/promise-pool": 3.0.0
     csv-parser: 3.0.0
     csv-writer: 1.6.0
   languageName: unknown
@@ -2283,7 +2284,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@supercharge/promise-pool@npm:^3.0.0":
+"@supercharge/promise-pool@npm:3.0.0":
   version: 3.0.0
   resolution: "@supercharge/promise-pool@npm:3.0.0"
   checksum: 761e7269e54b101c971f8436183c44def24f16a2a9928cfd3f937178fecceb259d4c752287e94dcb547237d9de1e52f1d15db14cb9c83148265cb67c38489a97
@@ -6075,7 +6076,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "ehpr@workspace:."
   dependencies:
-    "@supercharge/promise-pool": ^3.0.0
     "@tsconfig/node14": 1.0.1
     "@typescript-eslint/eslint-plugin": 5.0.0
     "@typescript-eslint/parser": 5.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -2283,6 +2283,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@supercharge/promise-pool@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@supercharge/promise-pool@npm:3.0.0"
+  checksum: 761e7269e54b101c971f8436183c44def24f16a2a9928cfd3f937178fecceb259d4c752287e94dcb547237d9de1e52f1d15db14cb9c83148265cb67c38489a97
+  languageName: node
+  linkType: hard
+
 "@szmarczak/http-timer@npm:^1.1.2":
   version: 1.1.2
   resolution: "@szmarczak/http-timer@npm:1.1.2"
@@ -6068,6 +6075,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "ehpr@workspace:."
   dependencies:
+    "@supercharge/promise-pool": ^3.0.0
     "@tsconfig/node14": 1.0.1
     "@typescript-eslint/eslint-plugin": 5.0.0
     "@typescript-eslint/parser": 5.0.0


### PR DESCRIPTION
**do not merge**

- data will come from .csv file manually generated

-  script that interfaces with our existing AWS SES instances 

-  able to send out templated emails

- able to read in a large email list from a file (5000+ emails)

-  rate limit and staggered sending capacity 

- re-sending capability default 5 retries

- log of failed sends

- store list of unsuccessful email in a file