### PR TITLE
EHPR-291 - add ability to send mass emails

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -29,6 +29,7 @@
     "@nestjs/platform-express": "8.2.3",
     "@nestjs/swagger": "5.1.5",
     "@nestjs/typeorm": "8.0.2",
+    "@supercharge/promise-pool": "3.1.1",
     "@vendia/serverless-express": "4.3.11",
     "aws-sdk": "2.1017.0",
     "class-transformer": "0.5.1",

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -8,6 +8,7 @@ import { UserModule } from './user/user.module';
 import { AuthModule } from './auth/auth.module';
 import { AdminModule } from './admin/admin.module';
 import { RegistrantModule } from './registrant/registrant.module';
+import { MassEmailRecordModule } from './mass-email-record/mass-email-record.module';
 
 @Module({
   imports: [
@@ -17,6 +18,7 @@ import { RegistrantModule } from './registrant/registrant.module';
     UserModule,
     AdminModule,
     RegistrantModule,
+    MassEmailRecordModule,
   ],
   controllers: [AppController],
   providers: [AppService, AppLogger],

--- a/apps/api/src/database/database.module.ts
+++ b/apps/api/src/database/database.module.ts
@@ -1,12 +1,13 @@
 import { Module, Logger } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { join } from 'path';
-import { SubmissionEntity } from 'src/submission/entity/submission.entity';
 import { LoggerOptions } from 'typeorm';
 import { PostgresConnectionOptions } from 'typeorm/driver/postgres/PostgresConnectionOptions';
 
 import config from '../ormconfig';
+import { SubmissionEntity } from 'src/submission/entity/submission.entity';
 import { UserEntity } from '../user/entity/user.entity';
+import { MassEmailRecordEntity } from '../mass-email-record/entity/mass-email-record.entity';
 
 const getEnvironmentSpecificConfig = (env?: string) => {
   switch (env) {
@@ -23,7 +24,7 @@ const getEnvironmentSpecificConfig = (env?: string) => {
         username: process.env.TEST_POSTGRES_USERNAME,
         password: process.env.TEST_POSTGRES_PASSWORD,
         database: process.env.TEST_POSTGRES_DATABASE,
-        entities: [SubmissionEntity, UserEntity],
+        entities: [SubmissionEntity, UserEntity, MassEmailRecordEntity],
         migrations: ['dist/migration/*.js'],
         logging: ['error', 'warn', 'migration'] as LoggerOptions,
       };

--- a/apps/api/src/mass-email-record/entity/mass-email-record.entity.ts
+++ b/apps/api/src/mass-email-record/entity/mass-email-record.entity.ts
@@ -1,0 +1,26 @@
+import { Column, CreateDateColumn, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { Exclude } from 'class-transformer';
+import { UserEntity } from 'src/user/entity/user.entity';
+import { GenericError } from 'src/common/generic-exception';
+
+@Entity('mass_email_record')
+export class MassEmailRecordEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'uuid', nullable: false })
+  userId!: string;
+
+  @Column({ type: 'jsonb', nullable: false })
+  recipients!: string[];
+
+  @Column({ type: 'jsonb', default: null })
+  errors?: GenericError[];
+
+  @CreateDateColumn()
+  @Exclude()
+  createdDate!: Date;
+
+  @ManyToOne(() => UserEntity, user => user.id)
+  user!: UserEntity;
+}

--- a/apps/api/src/mass-email-record/mass-email-record.module.ts
+++ b/apps/api/src/mass-email-record/mass-email-record.module.ts
@@ -1,0 +1,11 @@
+import { Logger, Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { MassEmailRecordService } from './mass-email-record.service';
+import { MassEmailRecordEntity } from './entity/mass-email-record.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([MassEmailRecordEntity])],
+  providers: [MassEmailRecordService, Logger],
+  exports: [MassEmailRecordService],
+})
+export class MassEmailRecordModule {}

--- a/apps/api/src/mass-email-record/mass-email-record.service.ts
+++ b/apps/api/src/mass-email-record/mass-email-record.service.ts
@@ -1,0 +1,63 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { PromisePoolError } from '@supercharge/promise-pool';
+import { AppLogger } from '../common/logger.service';
+import { MassEmailRecordEntity } from './entity/mass-email-record.entity';
+import { GenericError } from 'src/common/generic-exception';
+
+@Injectable()
+export class MassEmailRecordService {
+  constructor(
+    @InjectRepository(MassEmailRecordEntity)
+    private readonly massEmailRecordRepository: Repository<MassEmailRecordEntity>,
+    @Inject(Logger)
+    private readonly logger: AppLogger,
+  ) {}
+
+  async createMassEmailRecord(record: Partial<MassEmailRecordEntity>) {
+    const recordEntity = this.massEmailRecordRepository.create(record);
+    const result = await this.massEmailRecordRepository.save(recordEntity);
+    this.logger.log(`mass email record created: ${result.id}`);
+  }
+
+  /**
+   * maps data to a record entry for saving
+   *
+   * @param userId: requesting users id
+   * @param emailIds: list of registrant ids for corresponding emails
+   * @param errors: error object returned from PromisePool library
+   * @returns the created record
+   */
+  mapRecordObject(
+    userId: string,
+    emailIds: string[],
+    errors: PromisePoolError<{ status: string; name: string; message: string; userId: string }>[],
+  ): Partial<MassEmailRecordEntity> {
+    let mappedErrors: GenericError[] = [];
+    // general exceptions and AWS errors have different formats
+    // check for general exceptions then look for AWS errors
+    if (errors) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mappedErrors = errors.map(({ error, recipientId }: any) => {
+        const httpStatus = error?.status ?? undefined;
+        const errorType = error?.response?.error ?? error?.code;
+        const errorMessage = error?.response?.message ?? error?.message;
+        return {
+          httpStatus,
+          errorType,
+          errorMessage,
+          recipientId,
+        };
+      });
+    }
+
+    const record: Partial<MassEmailRecordEntity> = {
+      userId,
+      recipients: emailIds,
+      errors: mappedErrors,
+    };
+
+    return record;
+  }
+}

--- a/apps/api/src/migration/1707421827910-AddMassEmailRecordTable.ts
+++ b/apps/api/src/migration/1707421827910-AddMassEmailRecordTable.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddMassEmailTable1707313673269 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+        CREATE TABLE "mass_email_record" (
+            "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+            "user_id" uuid NOT NULL,
+            "recipients" jsonb NOT NULL,
+            "errors" jsonb,
+            "created_date" TIMESTAMP NOT NULL DEFAULT now(),
+            FOREIGN KEY("user_id") REFERENCES "user"("id") ON DELETE CASCADE
+        )
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "mass_email_record"`);
+  }
+}

--- a/apps/api/src/registrant/registrant.module.ts
+++ b/apps/api/src/registrant/registrant.module.ts
@@ -5,9 +5,10 @@ import { RegistrantService } from './registrant.service';
 import { RegistrantController } from './registrant.controller';
 import { UserModule } from 'src/user/user.module';
 import { MailModule } from 'src/mail/mail.module';
+import { MassEmailRecordModule } from 'src/mass-email-record/mass-email-record.module';
 
 @Module({
-  imports: [AuthModule, SubmissionModule, UserModule, MailModule],
+  imports: [AuthModule, SubmissionModule, UserModule, MailModule, MassEmailRecordModule],
   controllers: [RegistrantController],
   providers: [RegistrantService, Logger],
 })

--- a/apps/api/src/registrant/registrant.service.ts
+++ b/apps/api/src/registrant/registrant.service.ts
@@ -30,8 +30,8 @@ export class RegistrantService {
   }
 
   async sendMassEmail(payload: EmailTemplateDTO) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     // TODO: need to figure out a typing for this
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const errorsArray: any[] = [];
 
     try {

--- a/apps/api/src/registrant/registrant.service.ts
+++ b/apps/api/src/registrant/registrant.service.ts
@@ -1,9 +1,12 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, InternalServerErrorException, Logger } from '@nestjs/common';
 import { EmailTemplateDTO, RegistrantFilterDTO, RegistrantRO } from '@ehpr/common';
+import PromisePool from '@supercharge/promise-pool';
 import { SubmissionService } from 'src/submission/submission.service';
 import { formatRegistrants } from 'src/submission/submission.util';
 import { MailService } from 'src/mail/mail.service';
 import { MailOptions } from '../mail/types/mail-options';
+import { MassEmailRecordService } from 'src/mass-email-record/mass-email-record.service';
+import { AppLogger } from 'src/common/logger.service';
 
 @Injectable()
 export class RegistrantService {
@@ -12,6 +15,9 @@ export class RegistrantService {
     private readonly submissionService: SubmissionService,
     @Inject(MailService)
     private readonly mailService: MailService,
+    @Inject(MassEmailRecordService)
+    private readonly massEmailRecordService: MassEmailRecordService,
+    @Inject(Logger) private readonly logger: AppLogger,
   ) {}
 
   async getRegistrants(
@@ -24,13 +30,46 @@ export class RegistrantService {
   }
 
   async sendMassEmail(payload: EmailTemplateDTO) {
-    const mailOptions: MailOptions = {
-      body: payload.body,
-      from: process.env.MAIL_FROM ?? 'EHPRDoNotReply@dev.ehpr.freshworks.club',
-      subject: payload.subject,
-      to: payload.emails,
-    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    // TODO: need to figure out a typing for this
+    const errorsArray: any[] = [];
 
-    await this.mailService.sendMailWithSES(mailOptions);
+    try {
+      // setup promise pool
+      await PromisePool.withConcurrency(5)
+        .for(payload.data)
+        .handleError(async (error, recipient) => {
+          // have to handle errors manually with this handler
+          // to be able to access recipient id
+          errorsArray.push({ error, recipientId: recipient.id });
+        })
+        .process(async item => {
+          const mailOptions: MailOptions = {
+            body: payload.body,
+            from: process.env.MAIL_FROM ?? 'EHPRDoNotReply@dev.ehpr.freshworks.club',
+            subject: payload.subject,
+            to: [item.email],
+          };
+
+          await this.mailService.sendMailWithSES(mailOptions);
+        });
+    } catch (e) {
+      this.logger.error(e);
+      throw new InternalServerErrorException('There was an issue trying to send emails');
+    }
+
+    // no user id for test email
+    // create a record entry regardless if errored out
+    if (payload.userId) {
+      const emailIds = payload.data.map(({ id }) => id);
+      // format data for record entry
+      const record = this.massEmailRecordService.mapRecordObject(
+        payload.userId,
+        emailIds,
+        errorsArray,
+      );
+
+      await this.massEmailRecordService.createMassEmailRecord(record);
+    }
   }
 }

--- a/apps/api/src/user/entity/user.entity.ts
+++ b/apps/api/src/user/entity/user.entity.ts
@@ -1,6 +1,7 @@
-import { Column, Entity } from 'typeorm';
+import { Column, Entity, OneToMany } from 'typeorm';
 import { Role, User } from '@ehpr/common';
 import { BaseEntity } from '../../database/base.entity';
+import { MassEmailRecordEntity } from 'src/mass-email-record/entity/mass-email-record.entity';
 
 @Entity('user')
 export class UserEntity extends BaseEntity implements User {
@@ -18,4 +19,7 @@ export class UserEntity extends BaseEntity implements User {
 
   @Column({ type: 'timestamp', default: null })
   revokedDate!: Date | null;
+
+  @OneToMany(() => MassEmailRecordEntity, record => record.userId)
+  massEmailRecord!: MassEmailRecordEntity[];
 }

--- a/apps/web/src/components/email/TemplatePreview.tsx
+++ b/apps/web/src/components/email/TemplatePreview.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from 'react';
 import dynamic from 'next/dynamic';
 import { faWindowClose } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { Button, FullScreenModal, FullScreenModalFooter, useAuthContext } from '@components';
+import { Button, FullScreenModal, FullScreenModalFooter, Modal, useAuthContext } from '@components';
 import { sendMassEmail } from '@services';
 import { EmailData, EmailTemplate } from '@constants';
 
@@ -25,94 +25,141 @@ export const TemplatePreview = ({ emails, template, open, onClose }: TemplatePre
   // current list of select registrant emails
   const [showEmailList, setShowEmailList] = useState(false);
   const [loading, setLoading] = useState<boolean>(false);
+  const [showConfirmationModal, setShowConfirmationModal] = useState<boolean>(false);
 
   // handler for sending test email
   const handleSendEmailTest = async () => {
     setLoading(true);
     if (user?.email) {
-      await sendMassEmail({ subject: template.subject, body: template.body, emails: [user.email] });
+      await sendMassEmail({
+        subject: template.subject,
+        body: template.body,
+        data: [{ id: user.id, email: user.email }],
+      });
     }
     setLoading(false);
   };
 
+  // handler for sending mass email
+  const handleSendMassEmail = async () => {
+    setLoading(true);
+    const data = emails.map(e => ({ id: e.id, email: e.email }));
+    await sendMassEmail({
+      userId: user?.id,
+      subject: template.subject,
+      body: template.body,
+      data,
+    });
+    setLoading(false);
+    closeConfirmationModal();
+  };
   // handler for showing selected registrant emails for mass email send
   const handleShowEmailList = () => {
     setShowEmailList(prev => !prev);
   };
 
+  const openConfirmationModal = () => {
+    setShowConfirmationModal(true);
+  };
+
+  const closeConfirmationModal = () => {
+    setShowConfirmationModal(false);
+  };
+
   return (
-    <FullScreenModal open={open} handleClose={onClose}>
-      <FullScreenModal.Title className='flex flex-row text-lg font-bold leading-6 text-bcBlueLink border-b p-4'>
-        <div>Template Preview</div>
-        <button className='ml-auto' onClick={onClose}>
-          <FontAwesomeIcon icon={faWindowClose} size='2x' />
-        </button>
-      </FullScreenModal.Title>
-      <FullScreenModal.Description className='p-4'>
-        Please review the template and send a test email below:
-      </FullScreenModal.Description>
-
-      <div className='mx-5 mb-5 border-b'>
-        <Button
-          variant='primary'
-          type='submit'
-          onClick={() => handleSendEmailTest()}
-          loading={loading}
-        >
-          Send Test Email
-        </Button>
-        <p className='py-4'>
-          <i>This will send an email to the one tied to this current account.</i>
-        </p>
-      </div>
-
-      {/* read only editor for preview */}
-      <div className='mx-5 font-bold'>Subject Line</div>
-      <div className='flex flex-row p-2 my-1 mx-5 border '>
-        <input
-          name='subject-line'
-          type='text'
-          value={template.subject}
-          readOnly
-          className='flex-grow focus:outline-none'
-        />
-      </div>
-      <div className='mx-5 mt-2 font-bold'>Body</div>
-      <ReactQuill className='px-5 my-1' value={template.body} readOnly modules={modules} />
-      <div className='m-5'>
-        <Button variant='primary' onClick={() => handleShowEmailList()}>
-          Review Sending list
-        </Button>
-
-        {showEmailList && (
-          <div className='grid grid-cols-3 p-5 min-h-52 max-h-96 overflow-y-auto'>
-            <div className='col-span-3 my-3 mr-3'>
-              <strong>Total Emails:</strong> {emails.length}
-            </div>
-            {emails.map(({ email, name }) => (
-              <div key={email + name} className='w-full mb-2'>
-                <span>
-                  <strong>Name: </strong>
-                  {name}
-                </span>
-                <p>
-                  <strong>Email: </strong>
-                  {email}
-                </p>
-              </div>
-            ))}
+    <>
+      {showConfirmationModal ? (
+        <Modal open={showConfirmationModal} handleClose={closeConfirmationModal}>
+          <Modal.Title className='text-lg font-bold leading-6 text-bcBlueLink border-b p-4'>
+            Please Confirm
+          </Modal.Title>
+          {/* TODO: add legal disclaimer */}
+          <div className='p-4'>
+            Please confirm that you wish to send this email to {emails.length} registrants
           </div>
-        )}
-      </div>
-      <FullScreenModalFooter>
-        <Button variant='primary' onClick={onClose}>
-          Edit Template
-        </Button>
-        {/* TODO: implement mass email send */}
-        <Button variant='secondary' disabled={true}>
-          Send
-        </Button>
-      </FullScreenModalFooter>
-    </FullScreenModal>
+          <div className='p-4 mt-4 flex flex-row justify-between'>
+            <Button variant='secondary' onClick={closeConfirmationModal} disabled={loading}>
+              Cancel
+            </Button>
+            <Button variant='secondary' onClick={handleSendMassEmail} loading={loading}>
+              Send
+            </Button>
+          </div>
+        </Modal>
+      ) : (
+        <FullScreenModal open={open} handleClose={onClose}>
+          <FullScreenModal.Title className='flex flex-row text-lg font-bold leading-6 text-bcBlueLink border-b p-4'>
+            <div>Template Preview</div>
+            <button className='ml-auto' onClick={onClose}>
+              <FontAwesomeIcon icon={faWindowClose} size='2x' />
+            </button>
+          </FullScreenModal.Title>
+          <FullScreenModal.Description className='p-4'>
+            Please review the template and send a test email below:
+          </FullScreenModal.Description>
+
+          <div className='mx-5 mb-5 border-b'>
+            <Button
+              variant='primary'
+              type='submit'
+              onClick={() => handleSendEmailTest()}
+              loading={loading}
+            >
+              Send Test Email
+            </Button>
+            <p className='py-4'>
+              <b>This will send an email to: </b> {user?.email}
+            </p>
+          </div>
+
+          {/* read only editor for preview */}
+          <div className='mx-5 font-bold'>Subject Line</div>
+          <div className='flex flex-row p-2 my-1 mx-5 border '>
+            <input
+              name='subject-line'
+              type='text'
+              value={template.subject}
+              readOnly
+              className='flex-grow focus:outline-none'
+            />
+          </div>
+          <div className='mx-5 mt-2 font-bold'>Body</div>
+          <ReactQuill className='px-5 my-1' value={template.body} readOnly modules={modules} />
+          <div className='m-5'>
+            <Button variant='primary' onClick={() => handleShowEmailList()}>
+              Review Sending list
+            </Button>
+
+            {showEmailList && (
+              <div className='grid grid-cols-3 p-5 min-h-52 max-h-96 overflow-y-auto'>
+                <div className='col-span-3 my-3 mr-3'>
+                  <strong>Total Emails:</strong> {emails.length}
+                </div>
+                {emails.map(({ email, name }) => (
+                  <div key={email + name} className='w-full mb-2'>
+                    <span>
+                      <strong>Name: </strong>
+                      {name}
+                    </span>
+                    <p>
+                      <strong>Email: </strong>
+                      {email}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+          <FullScreenModalFooter>
+            <Button variant='primary' onClick={onClose}>
+              Edit Template
+            </Button>
+            <Button variant='secondary' onClick={openConfirmationModal} loading={loading}>
+              Confirm
+            </Button>
+          </FullScreenModalFooter>
+        </FullScreenModal>
+      )}
+    </>
   );
 };

--- a/packages/common/src/dto/email-template.dto.ts
+++ b/packages/common/src/dto/email-template.dto.ts
@@ -26,7 +26,7 @@ export class EmailTemplateDTO {
 
   @IsOptional()
   @IsString()
-  userId?: string | undefined;
+  userId?: string;
 
   @IsString()
   subject!: string;

--- a/packages/common/src/dto/email-template.dto.ts
+++ b/packages/common/src/dto/email-template.dto.ts
@@ -1,13 +1,32 @@
-import { IsArray, IsString } from 'class-validator';
+import { IsArray, IsOptional, IsString } from 'class-validator';
+
+export class RegistrantDataDTO {
+  constructor(base?: RegistrantDataDTO) {
+    if (base) {
+      this.id = base.id;
+      this.email = base.email;
+    }
+  }
+  @IsString()
+  id!: string;
+
+  @IsString()
+  email!: string;
+}
 
 export class EmailTemplateDTO {
   constructor(base?: EmailTemplateDTO) {
     if (base) {
+      this.userId = base.userId;
       this.subject = base.subject;
       this.body = base.body;
-      this.emails = base.emails;
+      this.data = base.data;
     }
   }
+
+  @IsOptional()
+  @IsString()
+  userId?: string | undefined;
 
   @IsString()
   subject!: string;
@@ -16,5 +35,5 @@ export class EmailTemplateDTO {
   body!: string;
 
   @IsArray()
-  emails!: string[];
+  data!: RegistrantDataDTO[];
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -859,6 +859,7 @@ __metadata:
     "@nestjs/swagger": 5.1.5
     "@nestjs/testing": 8.0.0
     "@nestjs/typeorm": 8.0.2
+    "@supercharge/promise-pool": 3.1.1
     "@types/aws-lambda": 8.10.84
     "@types/express": 4.17.13
     "@types/js-yaml": 4.0.5
@@ -2289,6 +2290,13 @@ __metadata:
   version: 1.2.3
   resolution: "@sqltools/formatter@npm:1.2.3"
   checksum: 5d80554b84ed15747fcfa6e488ef794c610c08152a53ebac0f270574ad938cdf39a02de7dfba4e9d9c33a790368f819945d315ee6dae360b220c29e092cba930
+  languageName: node
+  linkType: hard
+
+"@supercharge/promise-pool@npm:3.1.1":
+  version: 3.1.1
+  resolution: "@supercharge/promise-pool@npm:3.1.1"
+  checksum: 1495124de36f53d255fb9368d363e6499924958c58586be49bfd6354000c49be37829c4968af781195061a059c00a21557756517d559b8f7bcfe78f8adb2d633
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- added ability to send mass emails
- added `Promise Pool` for concurrency measures, currently set to 5, can be changed.
- added confirmation modal *added TODO to add legal disclaimer
- added `mass_email_record` table to keep records of all mass email sends
- will create an entry whether successful or not, saving errors