### PR TITLE
EHPR-302 -  filter registrants table by ha

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -9,6 +9,7 @@ import { AuthModule } from './auth/auth.module';
 import { AdminModule } from './admin/admin.module';
 import { RegistrantModule } from './registrant/registrant.module';
 import { MassEmailRecordModule } from './mass-email-record/mass-email-record.module';
+import { HealthAuthoritiesEntity } from './user/entity/ha.entity';
 
 @Module({
   imports: [
@@ -19,6 +20,7 @@ import { MassEmailRecordModule } from './mass-email-record/mass-email-record.mod
     AdminModule,
     RegistrantModule,
     MassEmailRecordModule,
+    HealthAuthoritiesEntity,
   ],
   controllers: [AppController],
   providers: [AppService, AppLogger],

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -9,7 +9,6 @@ import { AuthModule } from './auth/auth.module';
 import { AdminModule } from './admin/admin.module';
 import { RegistrantModule } from './registrant/registrant.module';
 import { MassEmailRecordModule } from './mass-email-record/mass-email-record.module';
-import { HealthAuthoritiesEntity } from './user/entity/ha.entity';
 
 @Module({
   imports: [
@@ -20,7 +19,6 @@ import { HealthAuthoritiesEntity } from './user/entity/ha.entity';
     AdminModule,
     RegistrantModule,
     MassEmailRecordModule,
-    HealthAuthoritiesEntity,
   ],
   controllers: [AppController],
   providers: [AppService, AppLogger],

--- a/apps/api/src/registrant/registrant.controller.ts
+++ b/apps/api/src/registrant/registrant.controller.ts
@@ -1,11 +1,16 @@
 import { Body, Controller, Get, Inject, Post, Query, Req, UseGuards } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
-import { EmailTemplateDTO, RegistrantFilterDTO, RegistrantRO, Role } from '@ehpr/common';
+import {
+  EmailTemplateDTO,
+  RegistrantFilterDTO,
+  RegistrantRO,
+  Role,
+  UserRequest,
+} from '@ehpr/common';
 import { AuthGuard } from '../auth/auth.guard';
 import { RegistrantService } from './registrant.service';
 import { Roles } from 'src/common/decorators';
 import { RoleGuard } from 'src/auth/role.guard';
-import { UserRequest } from '@ehpr/common';
 
 @Controller('registrants')
 @UseGuards(AuthGuard)

--- a/apps/api/src/registrant/registrant.controller.ts
+++ b/apps/api/src/registrant/registrant.controller.ts
@@ -1,28 +1,30 @@
-import { Body, Controller, Get, Inject, Post, Query, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Inject, Post, Query, Req, UseGuards } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { EmailTemplateDTO, RegistrantFilterDTO, RegistrantRO, Role } from '@ehpr/common';
 import { AuthGuard } from '../auth/auth.guard';
 import { RegistrantService } from './registrant.service';
-import { SubmissionService } from 'src/submission/submission.service';
 import { Roles } from 'src/common/decorators';
 import { RoleGuard } from 'src/auth/role.guard';
+import { UserRequest } from '@ehpr/common';
 
 @Controller('registrants')
 @UseGuards(AuthGuard)
 @ApiTags('Registrants')
 export class RegistrantController {
-  constructor(
-    @Inject(RegistrantService) private readonly registrantService: RegistrantService,
-    @Inject(SubmissionService) private readonly submissionService: SubmissionService,
-  ) {}
+  constructor(@Inject(RegistrantService) private readonly registrantService: RegistrantService) {}
 
   @Roles(Role.Admin, Role.User)
   @UseGuards(RoleGuard)
   @Get('/')
   async getRegistrants(
+    @Req() { user }: UserRequest,
     @Query() filter: RegistrantFilterDTO,
   ): Promise<[data: RegistrantRO[], count: number]> {
-    const registrants = await this.registrantService.getRegistrants(filter);
+    const registrants = await this.registrantService.getRegistrants(
+      filter,
+      user?.ha_id,
+      user?.email,
+    );
     return registrants;
   }
 

--- a/apps/api/src/registrant/registrant.service.ts
+++ b/apps/api/src/registrant/registrant.service.ts
@@ -23,8 +23,14 @@ export class RegistrantService {
 
   async getRegistrants(
     filter: RegistrantFilterDTO,
+    haId?: number,
+    userEmail?: string,
   ): Promise<[data: RegistrantRO[], count: number]> {
-    const [data, count] = await this.submissionService.getSubmissionsFilterQuery(filter);
+    const [data, count] = await this.submissionService.getSubmissionsFilterQuery(
+      filter,
+      haId,
+      userEmail,
+    );
 
     const registrants = formatRegistrants(data);
     return [registrants, count];

--- a/apps/api/src/submission/submission.module.ts
+++ b/apps/api/src/submission/submission.module.ts
@@ -4,9 +4,10 @@ import { MailModule } from 'src/mail/mail.module';
 import { SubmissionEntity } from './entity/submission.entity';
 import { SubmissionController } from './submission.controller';
 import { SubmissionService } from './submission.service';
+import { HealthAuthoritiesEntity } from 'src/user/entity/ha.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([SubmissionEntity]), MailModule],
+  imports: [TypeOrmModule.forFeature([SubmissionEntity, HealthAuthoritiesEntity]), MailModule],
   controllers: [SubmissionController],
   providers: [SubmissionService, Logger],
   exports: [SubmissionService],

--- a/apps/web/src/components/Pagination.tsx
+++ b/apps/web/src/components/Pagination.tsx
@@ -49,7 +49,7 @@ export const Pagination = (props: PaginationProps) => {
   }, [pageSize, pageIndex]);
 
   return (
-    <div className='flex flex-row w-full bg-white text-bcBlack border-b border-t'>
+    <div className='flex flex-row w-full bg-white text-bcBlack border-b border-t border-l'>
       <div className='text-sm py-4'>
         <span className='pl-6 mr-3'>Items per page: </span>
       </div>

--- a/apps/web/src/components/admin/AdminRegistrantsTable.tsx
+++ b/apps/web/src/components/admin/AdminRegistrantsTable.tsx
@@ -221,17 +221,15 @@ export const AdminRegistrantsTable = () => {
         <AdminSearch search={search} />
       </div>
       <div className='flex justify-end w-full my-5'>
-        {/* TODO: implement create mass email template/ button handler */}
         <Button variant='primary' onClick={createMassEmailTemplate} disabled={!emails.length}>
           Create Mass Email
         </Button>
       </div>
-      <div className='overflow-x-auto border border-bcLightGray rounded mb-5'>
-        <Pagination
-          pageOptions={{ pageIndex, pageSize: limit, total }}
-          onChange={handlePageOptions}
-        />
-
+      <Pagination
+        pageOptions={{ pageIndex, pageSize: limit, total }}
+        onChange={handlePageOptions}
+      />
+      <div className='overflow-x-auto border border-bcLightGray'>
         <table className='text-left w-full'>
           <thead className='whitespace-nowrap  text-bcBlack'>
             <tr className='border-b-2 bg-bcLightGray border-yellow-300 text-sm'>
@@ -242,6 +240,7 @@ export const AdminRegistrantsTable = () => {
                   value='all'
                   onChange={handleCheckboxChange}
                   checked={selectedPages.some(p => p.page === pageIndex && p.selected)}
+                  disabled={registrants.length === 0}
                 />
               </th>
               <th className='px-6' scope='col'>
@@ -290,24 +289,29 @@ export const AdminRegistrantsTable = () => {
                     {mapEnumData(reg.specialty, Specialty)}
                   </th>
                   <th className='px-6' scope='col'>
-                    {mapEnumData(reg.deploymentLocations, Location)}
+                    {!reg.deploymentLocations.length
+                      ? 'Any'
+                      : mapEnumData(reg.deploymentLocations, Location)}
                   </th>
                 </tr>
               ))
             ) : (
               <tr>
-                <td colSpan={5} className='text-lg text-center shadow-xs whitespace-nowrap text-sm'>
+                <td
+                  colSpan={6}
+                  className='text-lg text-center shadow-xs whitespace-nowrap font-bold py-5'
+                >
                   No Registrants were founds
                 </td>
               </tr>
             )}
           </tbody>
         </table>
-        <Pagination
-          pageOptions={{ pageIndex, pageSize: limit, total }}
-          onChange={handlePageOptions}
-        />
       </div>
+      <Pagination
+        pageOptions={{ pageIndex, pageSize: limit, total }}
+        onChange={handlePageOptions}
+      />
       {loading && (
         <div className='h-64'>
           <Spinner size='2x' />

--- a/apps/web/src/components/admin/AdminSearch.tsx
+++ b/apps/web/src/components/admin/AdminSearch.tsx
@@ -1,7 +1,9 @@
 import React, { useEffect, useState } from 'react';
-import { RegistrantFilterDTO } from '@ehpr/common';
+import { RegistrantFilterDTO, isMoh } from '@ehpr/common';
 import { SearchInput } from '../SearchInput';
 import { DEFAULT_PAGE_SIZE } from './AdminRegistrantsTable';
+import { GeneralCheckbox } from '../general';
+import { useAuthContext } from '../AuthProvider';
 
 interface SearchInputProps {
   search: (filters: RegistrantFilterDTO, limit: number) => void;
@@ -11,39 +13,61 @@ interface SearchInputProps {
 const QUERY_DELAY = 300;
 
 export const AdminSearch = (props: SearchInputProps) => {
+  const { user } = useAuthContext();
   const { search } = props;
 
   const [firstName, setFirstName] = useState<string>('');
   const [lastName, setLastName] = useState<string>('');
   const [email, setEmail] = useState<string>('');
+  const [anyRegion, setAnyRegion] = useState<boolean>(false);
 
   useEffect(() => {
     const timer = setTimeout(
-      () => search({ firstName, lastName, email }, DEFAULT_PAGE_SIZE),
+      () => search({ firstName, lastName, email, anyRegion }, DEFAULT_PAGE_SIZE),
       QUERY_DELAY,
     );
     return () => clearTimeout(timer);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [firstName, lastName, email]);
+  }, [firstName, lastName, email, anyRegion]);
+
+  const handleAnyRegionChange = () => {
+    setAnyRegion(prev => !prev);
+  };
 
   return (
-    <div className='relative bg-white z-10 flex flex-row items-center pl-5'>
-      {/* first name search input */}
-      <SearchInput
-        name='firstName'
-        value={firstName}
-        onChange={setFirstName}
-        placeholder='First name'
-      />
-      {/* last name search input */}
-      <SearchInput
-        name='lastName'
-        value={lastName}
-        onChange={setLastName}
-        placeholder='Last name'
-      />
-      {/* email search input */}
-      <SearchInput name='email' value={email} onChange={setEmail} placeholder='Email' />
-    </div>
+    <>
+      <div className='relative bg-white z-10 flex lg:flex-row md:flex-col sm:flex-col items-center pl-5'>
+        {/* first name search input */}
+        <SearchInput
+          name='firstName'
+          value={firstName}
+          onChange={setFirstName}
+          placeholder='First name'
+        />
+        {/* last name search input */}
+        <SearchInput
+          name='lastName'
+          value={lastName}
+          onChange={setLastName}
+          placeholder='Last name'
+        />
+        {/* email search input */}
+        <SearchInput name='email' value={email} onChange={setEmail} placeholder='Email' />
+      </div>
+      {/* no need to show this for MoH users, as they can see all registrants */}
+      {!isMoh(user?.email) && (
+        <div className='flex flex-row text-sm w-full ml-2'>
+          <GeneralCheckbox
+            name='any-region'
+            value='any-region'
+            onChange={handleAnyRegionChange}
+            checked={anyRegion}
+          />
+          <label htmlFor={'any-region'} className='pl-2'>
+            Show Any Region
+          </label>
+        </div>
+      )}
+    </>
   );
 };

--- a/apps/web/src/components/general/GeneralCheckbox.tsx
+++ b/apps/web/src/components/general/GeneralCheckbox.tsx
@@ -4,11 +4,12 @@ interface GeneralCheckboxProps {
   value: string;
   onChange: (checked: boolean, email: string) => void;
   checked?: boolean;
+  disabled?: boolean;
 }
 // generalized checkbox
 // not tied to Formik
 export const GeneralCheckbox = (props: GeneralCheckboxProps) => {
-  const { name, label, value, onChange, checked } = props;
+  const { name, label, value, onChange, checked, disabled } = props;
 
   const handleChange = (checked: boolean, email: string) => {
     onChange(checked, email);
@@ -28,6 +29,7 @@ export const GeneralCheckbox = (props: GeneralCheckboxProps) => {
         checked={checked}
         onChange={e => handleChange(e?.target?.checked, value)}
         className='h-4 w-4 min-w-4'
+        disabled={disabled}
       />
     </div>
   );

--- a/packages/common/src/constants/authorities.ts
+++ b/packages/common/src/constants/authorities.ts
@@ -1,53 +1,170 @@
 export interface Authority {
-  id: string;
+  condensedName: string;
   name: string;
   domains: string[];
 }
 
+export enum AuthoritiesFull {
+  FRASER_HEALTH_AUTHORITY = 'Fraser Health Authority',
+  VANCOUVER_ISLAND_HEALTH_AUTHORITY = 'Vancouver Island Health Authority',
+  VANCOUVER_COASTAL_HEALTH_AUTHORITY = 'Vancouver Coastal Health Authority',
+  INTERIOR_HEALTH_AUTHORITY = 'Interior Health Authority',
+  NORTHERN_HEALTH_AUTHORITY = 'Northern Health Authority',
+}
+
 export const Authorities: Record<string, Authority> = {
   MOH: {
-    id: 'MOH',
+    condensedName: 'MOH',
     name: 'Ministry of Health',
     domains: ['gov.bc.ca'],
   },
   FNHA: {
-    id: 'FNHA',
+    condensedName: 'FNHA',
     name: 'First Nations Health Authority',
     domains: ['fnha.ca'],
   },
   PHC: {
-    id: 'PHC',
+    condensedName: 'providence',
     name: 'Providence Health Care Society',
     domains: ['providencehealth.bc.ca'],
   },
   PHSA: {
-    id: 'PHSA',
+    condensedName: 'provincialHsa',
     name: 'Provincial Health Services Authority',
     domains: ['phsa.ca'],
   },
   FHA: {
-    id: 'FHA',
-    name: 'Fraser Health Authority',
+    condensedName: 'fraser',
+    name: AuthoritiesFull.FRASER_HEALTH_AUTHORITY,
     domains: ['fraserhealth.ca'],
   },
   IHA: {
-    id: 'IHA',
-    name: 'Interior Health Authority',
+    condensedName: 'interior',
+    name: AuthoritiesFull.INTERIOR_HEALTH_AUTHORITY,
     domains: ['interiorhealth.ca'],
   },
   VIHA: {
-    id: 'VIHA',
-    name: 'Vancouver Island Health Authority',
+    condensedName: 'vancouverIsland',
+    name: AuthoritiesFull.VANCOUVER_ISLAND_HEALTH_AUTHORITY,
     domains: ['islandhealth.ca'],
   },
   NHA: {
-    id: 'NHA',
-    name: 'Northern Health Authority',
+    condensedName: 'northern',
+    name: AuthoritiesFull.NORTHERN_HEALTH_AUTHORITY,
     domains: ['northernhealth.ca'],
   },
   VCHA: {
-    id: 'VCHA',
-    name: 'Vancouver Coastal Health Authority',
+    condensedName: 'vancouverCoastal',
+    name: AuthoritiesFull.VANCOUVER_COASTAL_HEALTH_AUTHORITY,
     domains: ['vch.ca'],
   },
+};
+
+// for comparing purposes in query filters
+// submissions are saved as these condensed versions without spaces
+export const FraserRegionLocations = [
+  'Hope',
+  'Chilliwack',
+  'Abbotsford',
+  'Mission',
+  'AgassizHarrison',
+  'NewWestminster',
+  'Burnaby',
+  'MapleRidgePittMeadows',
+  'TriCities',
+  'Langley',
+  'Delta',
+  'Surrey',
+  'SouthSurreyWhiteRock',
+];
+
+export const VancouverCoastalRegionLocations = [
+  'Richmond',
+  'Vancouver',
+  'NorthVancouver',
+  'WestVancouverBowenIsland',
+  'SunshineCoast',
+  'PowellRiver',
+  'HoweSound',
+  'BellaCoolaValley',
+  'CentralCoast',
+];
+
+export const VancouverIslandRegionLocations = [
+  'GreaterVictoria',
+  'WesternCommunities',
+  'SaanichPeninsula',
+  'SouthernGulfIslands',
+  'CowichanValleySouth',
+  'CowichanValleyWest',
+  'CowichanValleyNorth',
+  'GreaterNanaimo',
+  'Oceanside',
+  'AlberniClayoquot',
+  'ComoxValley',
+  'GreaterCampbellRiver',
+  'VancouverIslandWest',
+  'VancouverIslandNorth',
+];
+
+export const InteriorRegionLocations = [
+  'Fernie',
+  'Cranbrook',
+  'Kimberley',
+  'Windermere',
+  'Creston',
+  'Golden',
+  'KootenayLake',
+  'Nelson',
+  'Castlegar',
+  'ArrowLakes',
+  'Trail',
+  'GrandForks',
+  'KettleValley',
+  'SouthernOkanagan',
+  'Penticton',
+  'Keremeos',
+  'Princeton',
+  'ArmstrongSpallumcheen',
+  'Vernon',
+  'CentralOkanagan',
+  'Summerland',
+  'Enderby',
+  'Revelstoke',
+  'SalmonArm',
+  'Kamloops',
+  '100MileHouse',
+  'NorthThompson',
+  'CaribooChilcotin',
+  'Lillooet',
+  'SouthCariboo',
+  'Merritt',
+];
+
+export const NorthernRegionLocations = [
+  'HaidaGwaii',
+  'SnowCountry',
+  'PrinceRupert',
+  'UpperSkeena',
+  'Smithers',
+  'Kitimat',
+  'Stikine',
+  'Terrace',
+  'Nisgaa',
+  'TelegraphCreek',
+  'Quesnel',
+  'BurnsLake',
+  'Nechako',
+  'PrinceGeorge',
+  'PeaceRiverSouth',
+  'PeaceRiverNorth',
+  'FortNelson',
+];
+
+export const CondensedRegionLocations = {
+  [AuthoritiesFull.FRASER_HEALTH_AUTHORITY]: FraserRegionLocations,
+  [AuthoritiesFull.VANCOUVER_ISLAND_HEALTH_AUTHORITY]: VancouverIslandRegionLocations,
+  [AuthoritiesFull.VANCOUVER_COASTAL_HEALTH_AUTHORITY]: VancouverCoastalRegionLocations,
+  [AuthoritiesFull.INTERIOR_HEALTH_AUTHORITY]: InteriorRegionLocations,
+  [AuthoritiesFull.NORTHERN_HEALTH_AUTHORITY]: NorthernRegionLocations,
 };

--- a/packages/common/src/dto/registrant-filter.dto.ts
+++ b/packages/common/src/dto/registrant-filter.dto.ts
@@ -20,4 +20,7 @@ export class RegistrantFilterDTO {
   @IsNumberString()
   @IsOptional()
   limit?: number;
+
+  @IsOptional()
+  anyRegion?: boolean;
 }

--- a/packages/common/src/helper/is-moh.ts
+++ b/packages/common/src/helper/is-moh.ts
@@ -1,6 +1,10 @@
 import { Authorities } from '../constants';
 
-export const isMoh = (email: string) => {
+export const isMoh = (email?: string) => {
+  if (!email) {
+    return false;
+  }
+
   const domain = email.split('@')[1];
   const isMohDomain = Authorities.MOH.domains.includes(domain);
 


### PR DESCRIPTION
- add filter by health authority query
- will only show registrants with an interest in deploying to a location within logged in users HA
- add `Show Any Region` checkbox to show registrants with no deployment location preference

### Notes
- Providence has no region filter access (need to confirm, can take out)
- no access for First Nations/ Provincial ATM (need to confirm)

### Just HA registrants
![Screenshot 2024-02-22 at 1 51 22 PM](https://github.com/bcgov/ehpr2/assets/99211385/ec8c46bb-e7ad-4c42-8c4a-88c662875e6a)

## HA + registrants with no location preference
![Screenshot 2024-02-22 at 1 51 31 PM](https://github.com/bcgov/ehpr2/assets/99211385/f0d58706-610b-4e6b-88c1-35012624c364)
