### PR TITLE
add limiter library for aws ses sending rates

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -42,6 +42,7 @@
     "js-yaml": "4.1.0",
     "jsonwebtoken": "9.0.1",
     "jwks-rsa": "3.0.1",
+    "limiter": "2.1.0",
     "nanoid": "3.1.30",
     "nest-winston": "1.6.2",
     "nodemailer": "6.9.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -881,6 +881,7 @@ __metadata:
     js-yaml: 4.1.0
     jsonwebtoken: 9.0.1
     jwks-rsa: 3.0.1
+    limiter: 2.1.0
     nanoid: 3.1.30
     nest-winston: 1.6.2
     nodemailer: 6.9.4
@@ -11014,6 +11015,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"just-performance@npm:4.3.0":
+  version: 4.3.0
+  resolution: "just-performance@npm:4.3.0"
+  checksum: 37e226e308689b27ad7e0cdb2b2181c8be85f28cb0026db4b68c189f4894828a2865ea4a7a5f3488f4e3390bac1f9428fc6e40a554c068b08e5992e26920e376
+  languageName: node
+  linkType: hard
+
 "jwa@npm:^1.4.1":
   version: 1.4.1
   resolution: "jwa@npm:1.4.1"
@@ -11181,6 +11189,15 @@ __metadata:
   version: 2.0.4
   resolution: "lilconfig@npm:2.0.4"
   checksum: 02ae530aa49218d782eb79e92c600ea5220828987f85aa3403fa512cadc7efe38c0ac7d0cd2edf600ad3fae1f6c1752f5b4bb78c0d9950435b044d53d507c9e1
+  languageName: node
+  linkType: hard
+
+"limiter@npm:2.1.0":
+  version: 2.1.0
+  resolution: "limiter@npm:2.1.0"
+  dependencies:
+    just-performance: 4.3.0
+  checksum: 989092bfdafeefb37bd139f6451f165d449a628cd6fbe9308ed5147a9af24631f031e16466a3e48283418e0bea45c06aa1710f8f8945bc56ea7ef01f94ed5c65
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- added `limiter` library to reduce amount of requests per second to AWS
- set to 35 tokens/ requests per 1 second window
- AWS currently has a max of 40/s