### PR TITLE
Fix for request size limits

### DIFF
--- a/apps/api/src/app.config.ts
+++ b/apps/api/src/app.config.ts
@@ -54,6 +54,8 @@ export async function createNestApp(): Promise<{
     app.useLogger(new AppLogger());
   }
 
+  // Required for mass email request size
+  app.useBodyParser('json', { limit: '10mb' });
   // Api prefix api/v1/
   app.setGlobalPrefix(API_PREFIX);
 


### PR DESCRIPTION
Was getting request limits when sending larger amounts of emails. This fixes that. 