### PR TITLE
[EHPR] addressing CodeQL alerts

### DIFF
--- a/apps/api/src/registrant/registrant.service.ts
+++ b/apps/api/src/registrant/registrant.service.ts
@@ -179,7 +179,7 @@ export class RegistrantService {
         return replacements[key];
       }
 
-      return match; // Return the replacement or the original match if not found
+      return match; // Return the replacement or the original match if not located
     });
 
     return processedBody;

--- a/apps/api/src/registrant/registrant.service.ts
+++ b/apps/api/src/registrant/registrant.service.ts
@@ -101,7 +101,6 @@ export class RegistrantService {
           let body = '';
 
           if (data?.confirmationId && domain) {
-            //body = this.processTemplateBody(payload.body, { email: item.email, domain });
             body = this.processTemplateBody({
               templateBody: payload.body,
               email: item.email,
@@ -160,38 +159,29 @@ export class RegistrantService {
     domain,
     submissionData: { confirmationId, firstName, lastName, fullName },
   }: ProcessTemplate) {
-    enum RegexResult {
-      MATCH, // in format of ${word}
-      GROUP, // in format of word
-    }
-
-    const words = templateBody.matchAll(/\$\{([^}]+)\}/g);
-    let processedBody = templateBody;
+    type ReplacementKey = 'update_link' | 'first_name' | 'last_name' | 'full_name';
 
     const subUpdateUrl = domain
       ? `https://${domain}/update-submission?email=${email}&code=${confirmationId}`
       : `https://ehpr.gov.bc.ca/update-submission?email=${email}&code=${confirmationId}`;
 
+    const replacements: Record<ReplacementKey, string> = {
+      update_link: updateSubmissionLink(subUpdateUrl, 'Update your submission'),
+      first_name: firstName,
+      last_name: lastName,
+      full_name: fullName,
+    };
+
     // Replacing each coded word with selected string
-    for (const word of words) {
-      switch (word[RegexResult.GROUP].toLowerCase()) {
-        case 'update_link':
-          processedBody = processedBody.replace(
-            word[RegexResult.MATCH],
-            updateSubmissionLink(subUpdateUrl, 'Update your submission'),
-          );
-          break;
-        case 'first_name':
-          processedBody = processedBody.replace(word[RegexResult.MATCH], firstName);
-          break;
-        case 'last_name':
-          processedBody = processedBody.replace(word[RegexResult.MATCH], lastName);
-          break;
-        case 'full_name':
-          processedBody = processedBody.replace(word[RegexResult.MATCH], fullName);
-          break;
+    const processedBody = templateBody.replace(/\$\{([^}]+)\}/g, (match, group) => {
+      const key = group.toLowerCase() as ReplacementKey;
+      if (key in replacements) {
+        return replacements[key];
       }
-    }
+
+      return match; // Return the replacement or the original match if not found
+    });
+
     return processedBody;
   }
 

--- a/apps/api/src/registrant/registrant.service.ts
+++ b/apps/api/src/registrant/registrant.service.ts
@@ -173,7 +173,7 @@ export class RegistrantService {
     };
 
     // Replacing each coded word with selected string
-    const processedBody = templateBody.replace(/\$\{([^}]+)\}/g, (match, group) => {
+    const processedBody = templateBody.replace(/\$\{([^}{]+)\}/g, (match, group) => {
       const key = group.toLowerCase() as ReplacementKey;
       if (key in replacements) {
         return replacements[key];

--- a/apps/web/src/services/submission.ts
+++ b/apps/web/src/services/submission.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { DeepPartial, SubmissionType } from 'src/components/submission/validation';
 import { UpdateSubmissionDTO } from '@ehpr/common';
+import { isValidConfirmationId } from 'src/util';
 
 export const submitForm = async (submission: DeepPartial<SubmissionType>) => {
   // @todo when the form is fully implemented this object should be of type FormDTO
@@ -12,6 +13,10 @@ export const submitForm = async (submission: DeepPartial<SubmissionType>) => {
 };
 
 export const updateSubmission = async (confirmationId: string, payload: UpdateSubmissionDTO) => {
+  if (!isValidConfirmationId(confirmationId)) {
+    throw new Error('Invalid confirmation ID format');
+  }
+
   const { data } = await axios.patch(`/submission/${confirmationId}`, payload);
   return data.data;
 };

--- a/apps/web/src/services/submission.ts
+++ b/apps/web/src/services/submission.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { DeepPartial, SubmissionType } from 'src/components/submission/validation';
 import { UpdateSubmissionDTO } from '@ehpr/common';
-import { isValidConfirmationId } from 'src/util';
+import { isValidConfirmationId } from '../util';
 
 export const submitForm = async (submission: DeepPartial<SubmissionType>) => {
   // @todo when the form is fully implemented this object should be of type FormDTO

--- a/apps/web/src/util/index.ts
+++ b/apps/web/src/util/index.ts
@@ -1,2 +1,3 @@
 export * from './get-error-message';
 export * from './convert-params';
+export * from './validate-confirmation-id';

--- a/apps/web/src/util/validate-confirmation-id.ts
+++ b/apps/web/src/util/validate-confirmation-id.ts
@@ -1,0 +1,5 @@
+export const isValidConfirmationId = (id: string) => {
+  const confirmationPattern = /^[0-9A-NP-Z]{13}$/;
+
+  return confirmationPattern.test(id) && id.length === 13;
+};


### PR DESCRIPTION
In the security tab CodeQl has new alerts with code

I addressed these as follows
- Enforce a format check for api call
- Made template replacement more secure and faster