### PR TITLE
EHPR | Upgrade Zap Scan

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -75,7 +75,7 @@ jobs:
           make deploy-api
 
       - name: ZAP Scan
-        uses: zaproxy/action-full-scan@v0.3.0
+        uses: zaproxy/action-full-scan@v0.12.0
         with:
           target: ${{ secrets.DEV_URL }}
           cmd_options: '-I'

--- a/.github/workflows/pr-zap-prod.yml
+++ b/.github/workflows/pr-zap-prod.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           node-version: 16
       - name: ZAP Scan
-        uses: zaproxy/action-full-scan@v0.9.0
+        uses: zaproxy/action-full-scan@v0.12.0
         with:
           target: https://ehpr.gov.bc.ca/
           issue_title: PROD - ZAP Full Scan Report


### PR DESCRIPTION
- github action failed because of this zap scan version outdated
- upgrade the version to latest 0.12
![CleanShot 2024-11-26 at 07 49 10@2x](https://github.com/user-attachments/assets/d4647a62-6ce5-4d28-87e5-bc4a7ac48a49)
